### PR TITLE
add tests to demonstrate date ordering issue with topo sort

### DIFF
--- a/dulwich/tests/test_walk.py
+++ b/dulwich/tests/test_walk.py
@@ -144,6 +144,33 @@ class WalkerTest(TestCase):
         self.assertWalkYields([c4, c3], [c4.id], exclude=[c2.id])
         self.assertWalkYields([c4, c2], [c4.id], exclude=[c3.id])
 
+    def test_merge_of_new_branch_from_old_base(self):
+        # The commit on the branch was made at a time after any of the
+        # commits on master, but the branch was from an older commit.
+        # See also test_merge_of_old_branch
+        self.maxDiff = None
+        c1, c2, c3, c4, c5 = self.make_commits(
+            [[1], [2, 1], [3, 2], [4, 1], [5, 3, 4]],
+            times=[1, 2, 3, 4, 5],
+        )
+        self.assertWalkYields([c5, c4, c3, c2, c1], [c5.id])
+        self.assertWalkYields([c3, c2, c1], [c3.id])
+        self.assertWalkYields([c2, c1], [c2.id])
+
+    def test_merge_of_old_branch(self):
+        # The commit on the branch was made at a time before any of
+        # the commits on master, but it was merged into master after
+        # those commits.
+        # See also test_merge_of_new_branch_from_old_base
+        self.maxDiff = None
+        c1, c2, c3, c4, c5 = self.make_commits(
+            [[1], [2, 1], [3, 2], [4, 1], [5, 3, 4]],
+            times=[1, 3, 4, 2, 5],
+        )
+        self.assertWalkYields([c5, c4, c3, c2, c1], [c5.id])
+        self.assertWalkYields([c3, c2, c1], [c3.id])
+        self.assertWalkYields([c2, c1], [c2.id])
+
     def test_reverse(self):
         c1, c2, c3 = self.make_linear_commits(3)
         self.assertWalkYields([c1, c2, c3], [c3.id], reverse=True)


### PR DESCRIPTION
When the timestamp for a commit on a branch is older than the point at which it is being merged back into master, the topo sort does not produce the values in the same order as the git command line tool. So although the results are technically sorted in a correct topological form, they produce incorrect information when checking for the most recent tag or other information when traversing the results because the "old" commit appears later in the traversal than it should.

This patch adds 2 tests to demonstrate the problem. test_merge_of_new_branch_from_old_base() passes because the date on the commit being merged places it chronologically after the commits on master, but test_merge_of_old_branch() fails because the date on the commit being merged places it chronologically before the commits on master. Both are provided to illustrate the different input cases leading to the issue.

I don't necessarily expect the pull request to be applied, but it seemed an easy way to provide a test case.

I was able to solve the problem in the application where I'm using dulwich by writing my own traversal function (http://git.openstack.org/cgit/openstack/reno/tree/reno/scanner.py#n415) but I'm having some trouble translating that into a change in dulwich itself and am looking for advice about that (or about how I'm just using the TreeWalker wrong in the first place and that this isn't actually a bug).

I considered trying to modify dulwich.walk._topo_reorder(), but it doesn't have the right information about the "starting point" of the traversal, because by the time we get there the entries are already ordered by date. For reno I only want a single starting node to begin the traversal, but dulwich accepts an iterable for the "include" argument. At the very least my solution would need to be generalized to support multiple entries in the "include" list, and it's not clear how to get those nodes in the right order to start. Assume that the inputs are in the order desired?

I also considered changing dulwich.walk.TreeWalker.__iter__() to branch at that point based on the sorting requested, because there self.include is still available and the traversal could be handled correctly before the full sequence of entries is produced in date order. I'm afraid this would mean making more substantial changes to the way the iteration is handled, possibly by using a different queue class to replace _CommitTimeQueue.

And finally I considered adding a separate TopoTreeWalker class that never puts the entries in date order but only emits them in topological ordering. This seemed the least potentially disruptive to the existing implementation, but not necessarily best in terms of the existing API.

I'd like to work on a fix, but before I start making any significant changes I thought it best to see what your preference is for implementation. If you're interested in talking in real time, I'm available via IRC on freenode as "dhellmann". I live in the US Eastern time zone.