### PR TITLE
write_reflog: handle refs with arbitrary bytes

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -754,9 +754,8 @@ class Repo(BaseRepo):
     def _write_reflog(self, ref, old_sha, new_sha, committer, timestamp,
                       timezone, message):
         from .reflog import format_reflog_line
-        path = os.path.join(
-                self.controldir(), 'logs',
-                ref.decode(sys.getfilesystemencoding()))
+        cdir_path_bytes = self.controldir().encode(sys.getfilesystemencoding())
+        path = os.path.join(cdir_path_bytes, b'logs', ref)
         try:
             os.makedirs(os.path.dirname(path))
         except OSError as e:


### PR DESCRIPTION
5a8ba757f4b0fa92a1aa63ccfe9499e89c6a1a70 fixes the tests, but doesn't handle refs with arbitrary bytes. I think this is a better fix.