### PR TITLE
Add ability to use password and keyfile ssh options

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,8 @@
 
   * Start writing reflog entries. (Jelmer Vernooĳ)
 
+  * Add ability to use password and keyfile ssh options with SSHVendor. (Filipp Kucheryavy)
+
  API CHANGES
 
   * ``GitClient.send_pack`` now accepts a ``generate_pack_data``

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1111,8 +1111,8 @@ class SubprocessSSHVendor(SSHVendor):
                     password=None, key_filename=None):
         if password and key_filename:
             raise NotImplementedError(
-                "You can't set passphrase for ssh key with SubprocessSSHVendor, " \
-                "use ParamikoSSHVendor instead"
+                "You can't set passphrase for ssh key with "
+                "SubprocessSSHVendor, use ParamikoSSHVendor instead"
             )
 
         if sys.platform == 'win32':
@@ -1126,8 +1126,9 @@ class SubprocessSSHVendor(SSHVendor):
                 except OSError as e:
                     import warnings
                     warnings.warn(
-                        "You need sshpass for using password option, " \
-                        "you can use ssh-add or private key without password " \
+                        "You need sshpass for using password option, "
+                        "you can use ssh-add "
+                        "or private key without password "
                         "or ParamikoSSHVendor"
                     )
                     raise e

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1154,6 +1154,11 @@ class PuttySSHVendor(SSHVendor):
             args = ['putty', '-ssh']
 
         if password:
+            import warnings
+            warnings.warn(
+                "Putty show you password in clear text "
+                "in the list of arguments, so use ParamikoSSHVendor "
+                "instead if you care about security")
             args.extend(['-pw', str(password)])
 
         if port:

--- a/dulwich/contrib/paramiko_vendor.py
+++ b/dulwich/contrib/paramiko_vendor.py
@@ -131,9 +131,9 @@ class ParamikoSSHVendor(object):
             'gss_host': None,
             'banner_timeout': None,
             # commented due missing in old paramiko version
-            #'auth_timeout': None,
-            #'gss_trust_dns': True,
-            #'passphrase': None,
+            # 'auth_timeout': None,
+            # 'gss_trust_dns': True,
+            # 'passphrase': None,
         }
         self.ssh_kwargs.update(kwargs)
 

--- a/dulwich/contrib/paramiko_vendor.py
+++ b/dulwich/contrib/paramiko_vendor.py
@@ -114,28 +114,7 @@ class ParamikoSSHVendor(object):
     # http://docs.paramiko.org/en/2.4/api/client.html
 
     def __init__(self, **kwargs):
-        self.ssh_kwargs = {
-            'port': 22,
-            'username': None,
-            'password': None,
-            'pkey': None,
-            'key_filename': None,
-            'timeout': None,
-            'allow_agent': True,
-            'look_for_keys': True,
-            'compress': False,
-            'sock': None,
-            'gss_auth': False,
-            'gss_kex': False,
-            'gss_deleg_creds': True,
-            'gss_host': None,
-            'banner_timeout': None,
-            # commented due missing in old paramiko version
-            # 'auth_timeout': None,
-            # 'gss_trust_dns': True,
-            # 'passphrase': None,
-        }
-        self.ssh_kwargs.update(kwargs)
+        self.kwargs = kwargs
 
     def run_command(self, host, command,
                     username=None, port=None,
@@ -146,7 +125,7 @@ class ParamikoSSHVendor(object):
         client = paramiko.SSHClient()
 
         connection_kwargs = {'hostname': host}
-        connection_kwargs.update(self.ssh_kwargs)
+        connection_kwargs.update(self.kwargs)
         if username:
             connection_kwargs['username'] = username
         if port:

--- a/dulwich/tests/compat/test_client.py
+++ b/dulwich/tests/compat/test_client.py
@@ -327,7 +327,8 @@ class DulwichTCPClientTest(CompatTestCase, DulwichClientTestBase):
 class TestSSHVendor(object):
 
     @staticmethod
-    def run_command(host, command, username=None, port=None):
+    def run_command(host, command, username=None, port=None,
+                    password=None, key_filename=None):
         cmd, path = command.split(' ')
         cmd = cmd.split('-', 1)
         path = path.replace("'", "")

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -632,7 +632,7 @@ class TestSSHVendor(object):
         self.port = None
 
     def run_command(self, host, command, username=None, port=None,
-		    password=None, key_filename=None):
+                    password=None, key_filename=None):
         self.host = host
         self.command = command
         self.username = username

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -631,7 +631,8 @@ class TestSSHVendor(object):
         self.username = None
         self.port = None
 
-    def run_command(self, host, command, username=None, port=None):
+    def run_command(self, host, command, username=None, port=None,
+		    password=None, key_filename=None):
         self.host = host
         self.command = command
         self.username = username


### PR DESCRIPTION
Update for `SSHVendor`, `SubprocessSSHVendor`, `SSHGitClient` and `ParamikoSSHVendor` classes:

`SubprocessSSHVendor` now use `putty.exe` on `win32` platform and `sshpass` or `ssh` on other depend on the options.

`ParamikoSSHVendor` class currently most useful and can use all `paramiko.client.connect` options, but this options should be given on `__init__` call or with `run_command`. Also `SSHGitClient` can't pass this options except new `password` or `key_filename`