### PR TITLE
Fix `porcelain.fetch`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,8 @@
 
   * Fix tutorial tests on Python 3. (Jelmer Vernooĳ, #573)
 
+  * Fix remote refs created by `porcelain.fetch`. (Daniel Andersson, #623)
+
 0.19.2	2018-04-07
 
  BUG FIXES


### PR DESCRIPTION
In #614, `porcelain.fetch` was changed to write the updated local knowledge of the remote state to the repo, in a similar way as how it is done in `porcelain.clone`.

However, the implementation in `porcelain.fetch` did not strip the `refs/heads/` prefix on the remote refs before prefixing them with `refs/remotes/<remote_name>/`, which meant locally creating refs such as

    .git/refs/remotes/origin/refs/heads/master

instead of the correct form

    .git/refs/remotes/origin/master

This pull request addresses this by replacing the logic in `porcelain.fetch` with the one already present in `porcelain.clone`, and removing it entirely from `porcelain.clone` by letting it issue a call to `porcelain.fetch` instead.

An assertion is added to the `porcelain.fetch` tests to check that the local knowledge of the remote repository refs is correct after `porcelain.fetch` operations.