### PR TITLE
[FEATURE]  Add walks from cwd and not repo root

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -346,24 +346,40 @@ def clone(source, target=None, bare=False, checkout=None,
     return r
 
 
-def add(repo=".", paths=None):
+def add(repo=".", paths=None, all=False):
     """Add files to the staging area.
 
     :param repo: Repository for the files
-    :param paths: Paths to add.  No value passed stages all modified files.
+    :param paths: Paths to stage, stages all modified files in the CWD if None.
+    :param all: To stage everything in the repository, supersedes paths.
     :return: Tuple with set of added files and ignored files
     """
     ignored = set()
     with open_repo_closing(repo) as r:
         ignore_manager = IgnoreFilterManager.from_repo(r)
-        if not paths:
-            paths = list(
+        if all:
+            index = r.open_index()
+            paths = list(get_untracked_paths(r.path, r.path, r.open_index()))
+            paths += [
+                path.decode(sys.getfilesystemencoding())
+                for path in list(get_unstaged_changes(index, r.path))]
+        elif not paths:
+            index = r.open_index()
+            paths = [
+                os.path.join(r.path, path.decode(sys.getfilesystemencoding()))
+                for path in list(get_unstaged_changes(index, os.getcwd()))]
+            # deleted files should not be staged
+            paths = [path for path in paths if os.path.exists(path)]
+            paths += list(
                 get_untracked_paths(os.getcwd(), r.path, r.open_index()))
         relpaths = []
         if not isinstance(paths, list):
             paths = [paths]
         for p in paths:
-            relpath = os.path.relpath(p, r.path)
+            if all:
+                relpath = p
+            else:
+                relpath = os.path.relpath(p, r.path)
             if relpath.startswith('..' + os.path.sep):
                 raise ValueError('path %r is not in repo' % relpath)
             # FIXME: Support patterns, directories.

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -58,6 +58,7 @@ class PorcelainTestCase(TestCase):
     def setUp(self):
         super(PorcelainTestCase, self).setUp()
         self.test_dir = tempfile.mkdtemp()
+        os.mkdir(self.test_dir)
         self.addCleanup(shutil.rmtree, self.test_dir)
         self.repo = Repo.init(os.path.join(self.test_dir, 'repo'), mkdir=True)
         self.addCleanup(self.repo.close)
@@ -326,6 +327,38 @@ class AddTests(PorcelainTestCase):
             porcelain.add, self.repo,
             paths=["../foo"])
         self.assertEqual([], list(self.repo.open_index()))
+
+    def test_add_all_base(self):
+        os.mkdir(os.path.join(self.repo.path, 'foo'))
+        with open(os.path.join(self.repo.path, 'blah'), 'w') as f:
+            f.write("\n")
+        with open(os.path.join(self.repo.path, 'foo', 'blie'), 'w') as f:
+            f.write("\n")
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(os.path.join(self.repo.path, 'foo'))
+            porcelain.add(repo=self.repo.path, all=True)
+            porcelain.commit(repo=self.repo.path, message=b'test',
+                             author=b'test <email>',
+                             committer=b'test <email>')
+        finally:
+            os.chdir(cwd)
+
+    def test_add_all_and_paths(self):
+        os.mkdir(os.path.join(self.repo.path, 'foo'))
+        with open(os.path.join(self.repo.path, 'blah'), 'w') as f:
+            f.write("\n")
+        with open(os.path.join(self.repo.path, 'foo', 'blie'), 'w') as f:
+            f.write("\n")
+
+        porcelain.add(repo=self.repo.path, all=True,
+                      paths=[os.path.join(self.repo.path, 'blah')])
+        porcelain.commit(repo=self.repo.path, message=b'test',
+                         author=b'test <email>',
+                         committer=b'test <email>')
+        index = self.repo.open_index()
+        self.assertEqual(sorted(index), [b'blah', b'foo/blie'])
 
 
 class RemoveTests(PorcelainTestCase):


### PR DESCRIPTION
This might not be a fix but an implementation choice, but given the change is simple I thought I'd open a PR and see what happens.
 
**CONTEXT**
Currently when using add and not passing any paths to add, we walk though the current working directory instead of the repo root. This means that we are basically doing a `git add .`, assuming that the current working directory is in the repo, thus requiring to change the working directory if we are not located in it. It also means if we are using dulwich as an API in another git repo, let's say A, to modify B, then we will walk through A instead of our target B, even if the `repo` argu point to `B`. 

**CHANGES**

I think one of three two can and should be done:

1. If you think it is best to keep this behavior, I think adding an optional `all` argument to walk through the repo root would be useful, and better then forcing the user to switch working directory.
2. If you think that the logical thing would be to default to `all`, as the current doc implies, then switching `os.getcwd()` to `r.path` like I did does the trick.