### PR TITLE
refs: Clean-up parent directories when removing references

### DIFF
--- a/dulwich/tests/test_refs.py
+++ b/dulwich/tests/test_refs.py
@@ -462,6 +462,23 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
                 b'df6800012397fb85c56e7418dd4eb9405dee075c'))
         self.assertRaises(KeyError, lambda: self._refs[b'refs/tags/refs-0.1'])
 
+    def test_remove_parent(self):
+        self._refs[b'refs/heads/foo/bar'] = (
+            b'df6800012397fb85c56e7418dd4eb9405dee075c'
+        )
+        del self._refs[b'refs/heads/foo/bar']
+        ref_file = os.path.join(
+            self._refs.path, b'refs', b'heads', b'foo', b'bar',
+        )
+        self.assertFalse(os.path.exists(ref_file))
+        ref_file = os.path.join(self._refs.path, b'refs', b'heads', b'foo')
+        self.assertFalse(os.path.exists(ref_file))
+        ref_file = os.path.join(self._refs.path, b'refs', b'heads')
+        self.assertTrue(os.path.exists(ref_file))
+        self._refs[b'refs/heads/foo'] = (
+            b'df6800012397fb85c56e7418dd4eb9405dee075c'
+        )
+
     def test_read_ref(self):
         self.assertEqual(b'ref: refs/heads/master',
                          self._refs.read_ref(b'HEAD'))


### PR DESCRIPTION
The Git reference storage model has one dark corner which is that it doesn't support creating `refs/foo/bar/baz` when `refs/foo/bar` is already a reference. The reason for this is that internally the references are stored as a directory tree, so if `.git/refs/foo/bar/baz` exists, `.git/refs/foo/baz` is a directory on the filesystem so it cannot be a reference.

The flip side of this is that Git must clean up parent directories when it removes a reference, or it would not be possible to create `refs/foo/bar` after removing `refs/foo/bar/baz`. The canonical implementation does that.

This PR introduces the same clean-up in dulwich.