### PR TITLE
Simple describe implementation

### DIFF
--- a/bin/dulwich
+++ b/bin/dulwich
@@ -614,6 +614,14 @@ class cmd_ls_files(Command):
             print(name)
 
 
+class cmd_describe(Command):
+
+    def run(self, args):
+        parser = optparse.OptionParser()
+        options, args = parser.parse_args(args)
+        print(porcelain.describe('.'))
+
+
 class cmd_help(Command):
 
     def run(self, args):
@@ -644,6 +652,7 @@ commands = {
     "clone": cmd_clone,
     "commit": cmd_commit,
     "commit-tree": cmd_commit_tree,
+    "describe": cmd_describe,
     "daemon": cmd_daemon,
     "diff": cmd_diff,
     "diff-tree": cmd_diff_tree,

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -30,6 +30,7 @@ Currently implemented:
  * commit
  * commit-tree
  * daemon
+ * describe
  * diff-tree
  * fetch
  * init
@@ -61,6 +62,7 @@ from contextlib import (
     contextmanager,
 )
 from io import BytesIO
+import datetime
 import os
 import posixpath
 import stat
@@ -1286,3 +1288,72 @@ def ls_files(repo):
     """List all files in an index."""
     with open_repo_closing(repo) as r:
         return sorted(r.open_index())
+
+
+def describe(repo):
+    """Describe the repository version.
+
+    :param projdir: git repository root
+    :returns: a string description of the current git revision
+
+    Examples: "gabcdefh", "v0.1" or "v0.1-5-gabcdefh".
+    """
+    # Get the repository
+    with open_repo_closing(repo) as r:
+        # Get a list of all tags
+        refs = r.get_refs()
+        tags = {}
+        for key, value in refs.items():
+            key = key.decode()
+            obj = r.get_object(value)
+            if u'tags' not in key:
+                continue
+
+            _, tag = key.rsplit(u'/', 1)
+
+            try:
+                commit = obj.object
+            except AttributeError:
+                continue
+            else:
+                commit = r.get_object(commit[1])
+            tags[tag] = [
+                datetime.datetime(*time.gmtime(commit.commit_time)[:6]),
+                commit.id.decode('utf-8'),
+            ]
+
+        sorted_tags = sorted(tags.items(),
+                             key=lambda tag: tag[1][0],
+                             reverse=True)
+
+        # If there are no tags, return the current commit
+        if len(sorted_tags) == 0:
+            return 'g{}'.format(r[r.head()].id.decode('utf-8')[:7])
+
+        # We're now 0 commits from the top
+        commit_count = 0
+
+        # Get the latest commit
+        latest_commit = r[r.head()]
+
+        # Walk through all commits
+        walker = r.get_walker()
+        for entry in walker:
+            # Check if tag
+            commit_id = entry.commit.id.decode('utf-8')
+            for tag in sorted_tags:
+                tag_name = tag[0]
+                tag_commit = tag[1][1]
+                if commit_id == tag_commit:
+                    if commit_count == 0:
+                        return tag_name
+                    else:
+                        return '{}-{}-g{}'.format(
+                                tag_name,
+                                commit_count,
+                                latest_commit.id.decode('utf-8')[:7])
+
+            commit_count += 1
+
+        # Return plain commit if no parent tag can be found
+        return 'g{}'.format(latest_commit.id.decode('utf-8')[:7])

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -1375,3 +1375,59 @@ class FsckTests(PorcelainTestCase):
         self.assertEqual(
                 [(obj.id, 'invalid name .git')],
                 [(sha, str(e)) for (sha, e) in porcelain.fsck(self.repo)])
+
+
+class DescribeTests(PorcelainTestCase):
+
+    def test_no_commits(self):
+        self.assertRaises(KeyError, porcelain.describe, self.repo.path)
+
+    def test_single_commit(self):
+        fullpath = os.path.join(self.repo.path, 'foo')
+        with open(fullpath, 'w') as f:
+            f.write("BAR")
+        porcelain.add(repo=self.repo.path, paths=[fullpath])
+        sha = porcelain.commit(
+                self.repo.path, message=b"Some message",
+                author=b"Joe <joe@example.com>",
+                committer=b"Bob <bob@example.com>")
+        self.assertEqual(
+                'g{}'.format(str(sha)[:7]),
+                porcelain.describe(self.repo.path))
+
+    def test_tag(self):
+        fullpath = os.path.join(self.repo.path, 'foo')
+        with open(fullpath, 'w') as f:
+            f.write("BAR")
+        porcelain.add(repo=self.repo.path, paths=[fullpath])
+        porcelain.commit(
+                self.repo.path, message=b"Some message",
+                author=b"Joe <joe@example.com>",
+                committer=b"Bob <bob@example.com>")
+        porcelain.tag_create(self.repo.path, b"tryme", b'foo <foo@bar.com>',
+                             b'bar', annotated=True)
+        self.assertEqual(
+                "tryme",
+                porcelain.describe(self.repo.path))
+
+    def test_tag_and_commit(self):
+        fullpath = os.path.join(self.repo.path, 'foo')
+        with open(fullpath, 'w') as f:
+            f.write("BAR")
+        porcelain.add(repo=self.repo.path, paths=[fullpath])
+        porcelain.commit(
+                self.repo.path, message=b"Some message",
+                author=b"Joe <joe@example.com>",
+                committer=b"Bob <bob@example.com>")
+        porcelain.tag_create(self.repo.path, b"tryme", b'foo <foo@bar.com>',
+                             b'bar', annotated=True)
+        with open(fullpath, 'w') as f:
+            f.write("BAR2")
+        porcelain.add(repo=self.repo.path, paths=[fullpath])
+        sha = porcelain.commit(
+                self.repo.path, message=b"Some message",
+                author=b"Joe <joe@example.com>",
+                committer=b"Bob <bob@example.com>")
+        self.assertEqual(
+                'tryme-1-g{}'.format(str(sha)[:7]),
+                porcelain.describe(self.repo.path))


### PR DESCRIPTION
This has been used by Pext to generate the version strings shown in the about screen rather successfully for months now, so I feel okay enough with this to submit it upstream. It doesn't support all git describe does (no flags are supported), but it's a simple basic implementation that would fulfil the most common use cases.

![screenshot_20180701_201333](https://user-images.githubusercontent.com/1885159/42137352-3bc26646-7d6b-11e8-962d-2f6984972737.png)

