### PR TITLE
Pass the <errstream> parameter through from porcelain.clone() to porcelain.fetch().

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -326,7 +326,8 @@ def clone(source, target=None, bare=False, checkout=None,
 
     reflog_message = b'clone: from ' + source.encode('utf-8')
     try:
-        fetch_result = fetch(r, source, origin, message=reflog_message)
+        fetch_result = fetch(
+            r, source, origin, errstream=errstream, message=reflog_message)
         target_config = r.get_config()
         if not isinstance(source, bytes):
             source = source.encode(DEFAULT_ENCODING)


### PR DESCRIPTION
Without such, the `errstream` parameter only applies to

```python
errstream.write(b'Checking out ' + head.id + b'\n')
```

All other output, like that generated by `fetch()` (called by `clone()`), is
written, unwanted, to `porcelain.default_bytes_err_stream`.