### PR TITLE
Pass optional arguments to fetch() while cloning

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -327,7 +327,7 @@ def clone(source, target=None, bare=False, checkout=None,
     reflog_message = b'clone: from ' + source.encode('utf-8')
     try:
         fetch_result = fetch(
-            r, source, origin, errstream=errstream, message=reflog_message)
+            r, source, origin, errstream=errstream, message=reflog_message, **kwargs)
         target_config = r.get_config()
         if not isinstance(source, bytes):
             source = source.encode(DEFAULT_ENCODING)


### PR DESCRIPTION
All the optional params (including authentication) were directly passed to `get_transport_and_path()` function before. Now it's placed inside `fetch()` and this parameter passing is broken (which makes optional authentication configuration for `clone` impossible for example). Fixing it.