### PR TITLE
Add fallback for unavailable stdout/stderr

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,6 +84,7 @@ build_script:
 
 test_script:
   - "build.cmd %PYTHON%\\python.exe setup.py test"
+  - "build.cmd %PYTHON%\\pythonw.exe setup.py test"
 
 after_test:
   - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -61,7 +61,7 @@ from contextlib import (
     closing,
     contextmanager,
 )
-from io import BytesIO
+from io import BytesIO, RawIOBase
 import datetime
 import os
 import posixpath
@@ -139,8 +139,27 @@ from dulwich.server import (
 GitStatus = namedtuple('GitStatus', 'staged unstaged untracked')
 
 
-default_bytes_out_stream = getattr(sys.stdout, 'buffer', sys.stdout)
-default_bytes_err_stream = getattr(sys.stderr, 'buffer', sys.stderr)
+class NoneStream(RawIOBase):
+    """Fallback if stdout or stderr are unavailable, does nothing."""
+    def read(size=-1):
+        return None
+
+    def readall():
+        return None
+
+    def readinto(b):
+        return None
+
+    def write(b):
+        return None
+
+
+default_bytes_out_stream = getattr(
+        sys.stdout, 'buffer', sys.stdout
+    ) or NoneStream
+default_bytes_err_stream = getattr(
+        sys.stderr, 'buffer', sys.stderr
+    ) or NoneStream
 
 
 DEFAULT_ENCODING = 'utf-8'

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -141,25 +141,25 @@ GitStatus = namedtuple('GitStatus', 'staged unstaged untracked')
 
 class NoneStream(RawIOBase):
     """Fallback if stdout or stderr are unavailable, does nothing."""
-    def read(size=-1):
+    def read(self, size=-1):
         return None
 
-    def readall():
+    def readall(self):
         return None
 
-    def readinto(b):
+    def readinto(self, b):
         return None
 
-    def write(b):
+    def write(self, b):
         return None
 
 
 default_bytes_out_stream = getattr(
         sys.stdout, 'buffer', sys.stdout
-    ) or NoneStream
+    ) or NoneStream()
 default_bytes_err_stream = getattr(
         sys.stderr, 'buffer', sys.stderr
-    ) or NoneStream
+    ) or NoneStream()
 
 
 DEFAULT_ENCODING = 'utf-8'

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -79,6 +79,12 @@ class ArchiveTests(PorcelainTestCase):
         self.addCleanup(tf.close)
         self.assertEqual([], tf.getnames())
 
+    def test_simple_outstream_errstream_autofallback(self):
+        c1, c2, c3 = build_commit_graph(
+                self.repo.object_store, [[1], [2, 1], [3, 1, 2]])
+        self.repo.refs[b"refs/heads/master"] = c3.id
+        porcelain.archive(self.repo.path, b"refs/heads/master")
+
 
 class UpdateServerInfoTests(PorcelainTestCase):
 

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -233,7 +233,7 @@ class CloneTests(PorcelainTestCase):
         self.repo.refs[b"refs/heads/master"] = c1.id
         target_path = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, target_path)
-        errstream = porcelain.NoneStream
+        errstream = porcelain.NoneStream()
         r = porcelain.clone(
             self.repo.path, target_path, checkout=True, errstream=errstream)
         r.close()


### PR DESCRIPTION
I think theoretically this should fix #652, but I'm not sure how to properly test this, as I don't have a Windows machine myself so can't try it under pythonw.exe myself.