### PR TITLE
Don't double-decompress gzipped HTTP responses

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1435,10 +1435,7 @@ class HttpGitClient(GitClient):
         # `BytesIO`, if we can guarantee that the entire response is consumed
         # before issuing the next to still allow for connection reuse from the
         # pool.
-        if resp.getheader("Content-Encoding") == "gzip":
-            read = gzip.GzipFile(fileobj=BytesIO(resp.data)).read
-        else:
-            read = BytesIO(resp.data).read
+        read = BytesIO(resp.data).read
 
         resp.content_type = resp.getheader("Content-Type")
         resp.redirect_location = resp.get_redirect_location()


### PR DESCRIPTION
When using urllib3.response.HTTPResponse's data attribute, decompression of the
response contents is transparent.

HTTP(S) git remotes that deflate responses seem to be very uncommon; across my
testing only the Software Heritage forge seems to be doing this, and I'm tempted
to change the configuration there to stop doing it. However git upstream still
sends Accept-Encoding: gzip when talking to HTTP(S) remotes, so I think it makes
sense that dulwich keeps supporting it.

Reference: https://forge.softwareheritage.org/T1195
Test-Repository: https://forge.softwareheritage.org/source/helloworld.git