### PR TITLE
Make sure none of the ancestor folders of a new refname is in packed refs

### DIFF
--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -687,6 +687,16 @@ class DiskRefsContainer(RefsContainer):
         except (KeyError, IndexError):
             realname = name
         filename = self.refpath(realname)
+
+        # make sure none of the ancestor folders is in packed refs
+        probe_ref = os.path.dirname(realname)
+        packed_refs = self.get_packed_refs()
+        while probe_ref:
+            if packed_refs.get(probe_ref, None) is not None:
+                raise OSError(errno.ENOTDIR,
+                              'Not a directory: {}'.format(filename))
+            probe_ref = os.path.dirname(probe_ref)
+
         ensure_dir_exists(os.path.dirname(filename))
         with GitFile(filename, 'wb') as f:
             if old_ref is not None:

--- a/dulwich/tests/test_refs.py
+++ b/dulwich/tests/test_refs.py
@@ -340,6 +340,27 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
                          f.read()[:40])
         f.close()
 
+        self.assertRaises(
+            OSError, self._refs.__setitem__,
+            b'refs/some/ref/sub', b'42d06bd4b77fed026b154d16493e5deab78f02ec')
+
+    def test_setitem_packed(self):
+        # It's allowed to set a new ref on a packed ref, the new ref will be placed outside on refs/
+        self._refs[b'refs/heads/packed'] = (
+            b'3ec9c43c84ff242e3ef4a9fc5bc111fd780a76a8'
+        )
+        f = open(os.path.join(self._refs.path, b'refs', b'heads', b'packed'),
+                 'rb')
+        self.assertEqual(b'3ec9c43c84ff242e3ef4a9fc5bc111fd780a76a8',
+                         f.read()[:40])
+        f.close()
+
+        self._refs._packed_refs[b'refs/some/packed'] = b'42d06bd4b77fed026b154d16493e5deab78f02ec'
+        self.assertRaises(
+            OSError, self._refs.__setitem__,
+            b'refs/some/packed/sub',
+            b'42d06bd4b77fed026b154d16493e5deab78f02ec')
+
     def test_setitem_symbolic(self):
         ones = b'1' * 40
         self._refs[b'HEAD'] = ones


### PR DESCRIPTION
In Git, we cannot create a refname like `refs/head/child/grandchild` when there is already `refs/head/child`. This invariant covers refnames in packed-refs as well. This patch brings the same behaviour to `dulwich` packed-refs.

See behaviour of git below:

```
XPS-13-9370: test 
$> git init
Initialized empty Git repository in /home/mrkschan/tmp/test/.git/
                                                                                             
XPS-13-9370: test (master) 
$> touch README.md
                                                                                             
XPS-13-9370: test (master) 
$> git add README.md 
                                                                                             
XPS-13-9370: test (master)
$> git commit -m "init"
[master (root-commit) 6f0ef54] init
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 README.md

XPS-13-9370: test (master)
$> git checkout -b child master
Switched to a new branch 'child'

XPS-13-9370: test (child)
$> git checkout -b child/grandchild master
fatal: cannot lock ref 'refs/heads/child/grandchild': 'refs/heads/child' exists; cannot create 'refs/heads/child/grandchild'

XPS-13-9370: test (child)
$> git pack-refs --all

XPS-13-9370: test (child)
$> cat .git/packed-refs
# pack-refs with: peeled fully-peeled sorted
6f0ef54957df9b39ec5a195aae1585e5eaf2e9a9 refs/heads/child
6f0ef54957df9b39ec5a195aae1585e5eaf2e9a9 refs/heads/master

XPS-13-9370: test (child)
$> ls -la .git/refs/heads
total 8
drwxrwxr-x 2 mrkschan mrkschan 4096 Dec 19 21:42 .
drwxrwxr-x 4 mrkschan mrkschan 4096 Dec 19 21:41 ..

XPS-13-9370: test (child)
$> git checkout -b child/grandchild master
fatal: cannot lock ref 'refs/heads/child/grandchild': 'refs/heads/child' exists; cannot create 'refs/heads/child/grandchild'

XPS-13-9370: test (child)
$> git --version
git version 2.17.1
```