### PR TITLE
Activate the binary detection by default

### DIFF
--- a/dulwich/line_ending.py
+++ b/dulwich/line_ending.py
@@ -234,7 +234,7 @@ class BlobNormalizer(object):
         """
         if self.fallback_write_filter is not None:
             return normalize_blob(
-                blob, self.fallback_write_filter, binary_detection=False
+                blob, self.fallback_write_filter, binary_detection=True
             )
 
         return blob
@@ -244,7 +244,7 @@ class BlobNormalizer(object):
         """
         if self.fallback_read_filter is not None:
             return normalize_blob(
-                blob, self.fallback_read_filter, binary_detection=False
+                blob, self.fallback_read_filter, binary_detection=True
             )
 
         return blob

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1270,7 +1270,9 @@ class Repo(BaseRepo):
         """
         # TODO Parse the git attributes files
         git_attributes = {}
-        return BlobNormalizer(self.get_config_stack(), git_attributes)
+        return BlobNormalizer(
+            self.get_config_stack(), git_attributes
+        )
 
 
 class MemoryRepo(BaseRepo):


### PR DESCRIPTION
https://github.com/dulwich/dulwich/pull/674 added automatic binary detection but didn't exposed a way to activate it from the BlobNormalizer layer.

I've added the basic argument to allow to activate it. But there is some usage of BlobNormalizer internally (in the `repo.stage` method and in the `porcelain.status` function). Should we activate the binary detection by default? Should we expose a parameter in repo to set it?

One piece of design to keep in mind, it is possible through `.gitattributes` file to force a file to be detected as a binary file or as a text file, no matter what its actual content is. So there will be some cases where the `binary_detection` will be set to off when calling `normalize_blob` once the `.gitattributes` will be added.