### PR TITLE
Fix url redirect location handling in HttpGitClient

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -146,5 +146,6 @@ Sylvia van Os <sylvia@hackerchick.me>
 Boris Feld <lothiraldan@gmail.com>
 KS Chan <mrkschan@gmail.com>
 egor <egor@sourced.tech>
+Antoine Lambert <anlambert@softwareheritage.org>
 
 If you contributed but are missing from this list, please send me an e-mail.

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1517,7 +1517,8 @@ class HttpGitClient(GitClient):
         read = BytesIO(resp.data).read
 
         resp.content_type = resp.getheader("Content-Type")
-        resp.redirect_location = resp.get_redirect_location()
+        resp_url = resp.geturl()
+        resp.redirect_location = resp_url if resp_url != url else ''
 
         return resp, read
 


### PR DESCRIPTION
I noticed it was impossible to clone a GitLab hosted repository using dulwich when its url is not suffixed by `.git`. For instance while it is possible to do a `git clone` on this repository https://git.gnu.io/gnu/gnuio, trying to do the same operation with dulwich gives me the following:

```
Python 3.5.3 (default, Sep 27 2018, 17:25:39) 
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from dulwich.porcelain import clone
>>> clone('https://git.gnu.io/gnu/gnuio')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/antoine/dev/dulwich/dulwich/porcelain.py", line 353, in clone
    depth=depth, **kwargs)
  File "/home/antoine/dev/dulwich/dulwich/porcelain.py", line 1119, in fetch
    depth=depth)
  File "/home/antoine/dev/dulwich/dulwich/client.py", line 398, in fetch
    progress=progress, depth=depth)
  File "/home/antoine/dev/dulwich/dulwich/client.py", line 1661, in fetch_pack
    "git-upload-pack", url, data=req_data.getvalue())
  File "/home/antoine/dev/dulwich/dulwich/client.py", line 1569, in _smart_request
    resp, read = self._http_request(url, headers, data)
  File "/home/antoine/dev/dulwich/dulwich/client.py", line 1507, in _http_request
    raise NotGitRepository()
dulwich.errors.NotGitRepository
```
While suffixing the repository url with `.git`, the clone work as expected:
```
Python 3.5.3 (default, Sep 27 2018, 17:25:39) 
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from dulwich.porcelain import clone
>>> clone('https://git.gnu.io/gnu/gnuio.git')
Enumerating objects: 114, done.
Counting objects: 100% (114/114), done.
<Repo at 'gnuio.git'> 76% (66/86)   
Compressing objects: 100% (86/86), done.
Total 114 (delta 47), reused 65 (delta 24)
Checking out 06fa7c58034eab05b1bfbbe2d546ce73f3b19629
``` 
As we can see from this `git` debug output, there is an url redirection from https://git.gnu.io/gnu/gnuio to https://git.gnu.io/gnu/gnuio.git:

```
16:48 $ GIT_CURL_VERBOSE=1 git clone https://git.gnu.io/gnu/gnuio
Clonage dans 'gnuio'...
* Couldn't find host git.gnu.io in the .netrc file; using defaults
*   Trying 45.55.158.37...
* TCP_NODELAY set
* Connected to git.gnu.io (45.55.158.37) port 443 (#0)
* found 151 certificates in /etc/ssl/certs/ca-certificates.crt
* found 608 certificates in /etc/ssl/certs
* ALPN, offering http/1.1
* SSL connection using TLS1.2 / ECDHE_RSA_AES_256_GCM_SHA384
*        server certificate verification OK
*        server certificate status verification SKIPPED
*        common name: git.gnu.io (matched)
*        server certificate expiration date OK
*        server certificate activation date OK
*        certificate public key: RSA
*        certificate version: #3
*        subject: CN=git.gnu.io
*        start date: Tue, 08 Jan 2019 02:00:33 GMT
*        expire date: Mon, 08 Apr 2019 02:00:33 GMT
*        issuer: C=US,O=Let's Encrypt,CN=Let's Encrypt Authority X3
*        compression: NULL
* ALPN, server accepted to use http/1.1
> GET /gnu/gnuio/info/refs?service=git-upload-pack HTTP/1.1
Host: git.gnu.io
User-Agent: git/2.11.0
Accept: */*
Accept-Encoding: gzip
Accept-Language: fr-FR, *;q=0.9
Pragma: no-cache

< HTTP/1.1 301 Moved Permanently
< Server: nginx
< Date: Mon, 21 Jan 2019 15:48:17 GMT
< Content-Type: text/html
< Content-Length: 132
< Connection: keep-alive
< Cache-Control: no-cache
< Location: https://git.gnu.io/gnu/gnuio.git/info/refs?service=git-upload-pack
< X-Request-Id: 6QzCXdgTQ35
< X-Runtime: 0.012122
< Strict-Transport-Security: max-age=31536000
< 
* Ignoring the response-body
* Curl_http_done: called premature == 0
* Connection #0 to host git.gnu.io left intact
* Issue another request to this URL: 'https://git.gnu.io/gnu/gnuio.git/info/refs?service=git-upload-pack'
* Couldn't find host git.gnu.io in the .netrc file; using defaults
* Found bundle for host git.gnu.io: 0x56445874eef0 [can pipeline]
* Re-using existing connection! (#0) with host git.gnu.io
* Connected to git.gnu.io (45.55.158.37) port 443 (#0)
> GET /gnu/gnuio.git/info/refs?service=git-upload-pack HTTP/1.1
Host: git.gnu.io
User-Agent: git/2.11.0
Accept: */*
Accept-Encoding: gzip
Accept-Language: fr-FR, *;q=0.9
Pragma: no-cache

< HTTP/1.1 200 OK
< Server: nginx
< Date: Mon, 21 Jan 2019 15:48:17 GMT
< Content-Type: application/x-git-upload-pack-advertisement
< Content-Length: 567
< Connection: keep-alive
< Cache-Control: no-cache
< Strict-Transport-Security: max-age=31536000
...
```
So I suspected the url redirection was not properly handled by dulwich.

It turns out that the `urllib3` module used by dulwich under the hood to make HTTP requests handles automatic redirection by default (see https://urllib3.readthedocs.io/en/latest/reference/index.html#urllib3.connectionpool.HTTPConnectionPool.urlopen). This means that calling method `urllib3.response.HTTPResponse.get_redirect_location` (https://urllib3.readthedocs.io/en/latest/reference/index.html#urllib3.response.HTTPResponse.get_redirect_location) always returns `False`
as the url redirection was already performed.

That PR simply modifies the way to check if an url redirection has been performed and thus fix the clone operation when a repository url is redirected.


