### PR TITLE
Update directory detection for `get_unstaged_changes` for Python 3 - …

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -605,7 +605,9 @@ def read_submodule_head(path):
 
 
 def has_directory_changed(error, tree_path, entry):
-    """ When handling an error trying to create a blob from a path, call this
+    """ check if a directory has changed after getting an error
+
+    When handling an error trying to create a blob from a path, call this
     function. It will check if the path is a directory. If it's a directory
     and a submodule, check the submodule head to see if it's has changed. If
     not, consider the file as changed as Git tracked a file and not a

--- a/dulwich/tests/test_index.py
+++ b/dulwich/tests/test_index.py
@@ -671,6 +671,52 @@ class GetUnstagedChangesTests(TestCase):
 
             self.assertEqual(list(changes), [b'foo1'])
 
+    def test_get_unstaged_changes_removed_replaced_by_directory(self):
+        """Unit test for get_unstaged_changes."""
+
+        repo_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, repo_dir)
+        with Repo.init(repo_dir) as repo:
+
+            # Commit a dummy file then modify it
+            foo1_fullpath = os.path.join(repo_dir, 'foo1')
+            with open(foo1_fullpath, 'wb') as f:
+                f.write(b'origstuff')
+
+            repo.stage(['foo1'])
+            repo.do_commit(b'test status', author=b'author <email>',
+                           committer=b'committer <email>')
+
+            os.remove(foo1_fullpath)
+            os.mkdir(foo1_fullpath)
+
+            changes = get_unstaged_changes(repo.open_index(), repo_dir)
+
+            self.assertEqual(list(changes), [b'foo1'])
+
+    def test_get_unstaged_changes_removed_replaced_by_link(self):
+        """Unit test for get_unstaged_changes."""
+
+        repo_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, repo_dir)
+        with Repo.init(repo_dir) as repo:
+
+            # Commit a dummy file then modify it
+            foo1_fullpath = os.path.join(repo_dir, 'foo1')
+            with open(foo1_fullpath, 'wb') as f:
+                f.write(b'origstuff')
+
+            repo.stage(['foo1'])
+            repo.do_commit(b'test status', author=b'author <email>',
+                           committer=b'committer <email>')
+
+            os.remove(foo1_fullpath)
+            os.symlink(os.path.dirname(foo1_fullpath), foo1_fullpath)
+
+            changes = get_unstaged_changes(repo.open_index(), repo_dir)
+
+            self.assertEqual(list(changes), [b'foo1'])
+
 
 class TestValidatePathElement(TestCase):
 

--- a/dulwich/tests/test_index.py
+++ b/dulwich/tests/test_index.py
@@ -694,6 +694,7 @@ class GetUnstagedChangesTests(TestCase):
 
             self.assertEqual(list(changes), [b'foo1'])
 
+    @skipIf(not can_symlink(), 'Requires symlink support')
     def test_get_unstaged_changes_removed_replaced_by_link(self):
         """Unit test for get_unstaged_changes."""
 


### PR DESCRIPTION
…fix #684

The exception raised when trying to read a directory changed from an `IOError`
in Python 2 to an `IsADirectoryError` in Python 3 (`IsADirectoryError` is a
subclass of `OSError`).

`IsADirectoryError` doesn't exists in Python 2 so we have to makes extra hops
to have a check compatible with both Python 2 and Python 3.