### PR TITLE
porcelain clean (issue 398)

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -409,9 +409,9 @@ def add(repo=".", paths=None):
 
 
 def is_subdir(subdir, parentdir):
-    """Check whether `subdir` is `parentdir` or a subdir of `parentdir`
+    """Check whether subdir is parentdir or a subdir of parentdir
 
-        If `parentdir` or `subdir` is a relative path, it will be disamgibuated
+        If parentdir or subdir is a relative path, it will be disamgibuated
         relative to the pwd.
     """
     parentdir_abs = os.path.realpath(parentdir)
@@ -419,10 +419,11 @@ def is_subdir(subdir, parentdir):
     return subdir_abs.startswith(parentdir_abs)
     
 
+# TODO: option to remove ignored files also, in line with `git clean -fdx`
 def clean(repo=".", target_dir=None):
     """Remove any untracked files from the target directory recursively
 
-    Equivalent to running git clean -fd in `target_dir`.
+    Equivalent to running `git clean -fd` in target_dir.
 
     :param repo: Repository where the files may be tracked
     :param target_dir: Directory to clean - defaults to current directory if None

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -451,7 +451,10 @@ def clean(repo=".", target_dir=None):
             else:
                 ip = path_to_tree_path(r.path, ap)
                 is_tracked = ip in index
-                is_ignored = ignore_manager.is_ignored(ip)
+
+                rp = os.path.relpath(ap, r.path)
+                is_ignored = ignore_manager.is_ignored(rp)
+
                 if not is_tracked and not is_ignored:
                     os.remove(ap)
 

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -408,18 +408,22 @@ def add(repo=".", paths=None):
     return (relpaths, ignored)
 
 
-def clean(repo="."):
-    """Remove any untracked files from the current directory recursively
+def clean(repo=".", target_dir=None):
+    """Remove any untracked files from the target directory recursively
 
-    Equivalent to git clean -fd.
+    Equivalent to running git clean -fd in target_dir.
 
     :param repo: Repository where the files may be tracked
+    :param target_dir: Directory to clean - defaults to current directory if None
     """
     with open_repo_closing(repo) as r:
+        if target_dir is None:
+            target_dir = os.getcwd()
+         
         index = r.open_index()
         ignore_manager = IgnoreFilterManager.from_repo(r)
         
-        paths_in_wd = walk_working_dir_paths(os.getcwd(), r.path)
+        paths_in_wd = walk_working_dir_paths(target_dir, r.path)
         # Reverse file visit order, so that files and subdirectories are removed before
         # containing directory
         for ap, is_dir in reversed(list(paths_in_wd)):
@@ -952,6 +956,7 @@ def walk_working_dir_paths(frompath, basepath):
         for filename in filenames:
             filepath = os.path.join(dirpath, filename)
             yield filepath, False
+
 
      
         

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -408,18 +408,32 @@ def add(repo=".", paths=None):
     return (relpaths, ignored)
 
 
+def is_subdir(subdir, parentdir):
+    """Check whether `subdir` is `parentdir` or a subdir of `parentdir`
+
+        If `parentdir` or `subdir` is a relative path, it will be disamgibuated
+        relative to the pwd.
+    """
+    parentdir_abs = os.path.realpath(parentdir)
+    subdir_abs = os.path.realpath(subdir)
+    return subdir_abs.startswith(parentdir_abs)
+    
+
 def clean(repo=".", target_dir=None):
     """Remove any untracked files from the target directory recursively
 
-    Equivalent to running git clean -fd in target_dir.
+    Equivalent to running git clean -fd in `target_dir`.
 
     :param repo: Repository where the files may be tracked
     :param target_dir: Directory to clean - defaults to current directory if None
     """
-    with open_repo_closing(repo) as r:
-        if target_dir is None:
-            target_dir = os.getcwd()
-         
+    if target_dir is None:
+        target_dir = os.getcwd()
+    
+    if not is_subdir(target_dir, repo):
+        raise ValueError("target_dir must be in the repo's working dir")
+
+    with open_repo_closing(repo) as r:        
         index = r.open_index()
         ignore_manager = IgnoreFilterManager.from_repo(r)
         

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -414,8 +414,8 @@ def _is_subdir(subdir, parentdir):
         If parentdir or subdir is a relative path, it will be disamgibuated
         relative to the pwd.
     """
-    parentdir_abs = os.path.realpath(parentdir)
-    subdir_abs = os.path.realpath(subdir)
+    parentdir_abs = os.path.realpath(parentdir) + os.path.sep
+    subdir_abs = os.path.realpath(subdir) + os.path.sep
     return subdir_abs.startswith(parentdir_abs)
 
 

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -185,10 +185,15 @@ class CleanTests(PorcelainTestCase):
         """
         control_dir = self.repo._controldir
         control_dir_rel = os.path.relpath(control_dir, self.repo.path)
+
+        # normalize paths to simplify comparison across platforms
+        from os.path import normpath
         found_paths = {
-            p for p in flat_walk_dir(self.repo.path)
+            normpath(p)
+            for p in flat_walk_dir(self.repo.path)
             if not p.split(os.sep)[0] == control_dir_rel}
-        self.assertEqual(found_paths, expected_paths)
+        norm_expected_paths = {normpath(p) for p in expected_paths}
+        self.assertEqual(found_paths, norm_expected_paths)
 
     def test_from_root(self):
         self.put_files(


### PR DESCRIPTION
Resolves #398. 

Implements `dulwich.porcelain.clean`, which is equivalent to `git clean -fd`. In the future, it will be straightforward to add an option to also remove ignored files )(equivalent to `git clean -fdx`).