### PR TITLE
ignore: question mark should not match slash

### DIFF
--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -38,7 +38,7 @@ def _translate_segment(segment):
         if c == b'*':
             res += b'[^/]*'
         elif c == b'?':
-            res += b'.'
+            res += b'[^/]'
         elif c == b'[':
             j = i
             if j < n and segment[j:j+1] == b'!':

--- a/dulwich/tests/test_ignore.py
+++ b/dulwich/tests/test_ignore.py
@@ -65,6 +65,7 @@ NEGATIVE_MATCH_TESTS = [
     (b"foo/foo.c", b"/*.c"),
     (b"foo/bar/", b"/bar/"),
     (b"foo/bar/", b"foo/bar/*"),
+    (b"foo/bar", b"foo?bar")
 ]
 
 


### PR DESCRIPTION
According to [git docs](https://github.com/git/git/blob/041f5ea1cf987a4068ef5f39ba0a09be85952064/Documentation/gitignore.txt#L106)
`?` should not match `/`

