### PR TITLE
Rename submodule into subproject in diff to match CGit behavior

### DIFF
--- a/dulwich/patch.py
+++ b/dulwich/patch.py
@@ -192,7 +192,7 @@ def write_object_diff(f, store, old_file, new_file, diff_binary=False):
         if hexsha is None:
             return Blob.from_string(b'')
         elif S_ISGITLINK(mode):
-            return Blob.from_string(b"Submodule commit " + hexsha + b"\n")
+            return Blob.from_string(b"Subproject commit " + hexsha + b"\n")
         else:
             return store[hexsha]
 

--- a/dulwich/tests/test_patch.py
+++ b/dulwich/tests/test_patch.py
@@ -363,8 +363,8 @@ class DiffTests(TestCase):
             b'--- a/asubmodule',
             b'+++ b/asubmodule',
             b'@@ -1 +1 @@',
-            b'-Submodule commit 06d0bdd9e2e20377b3180e4986b14c8549b393e4',
-            b'+Submodule commit cc975646af69f279396d4d5e1379ac6af80ee637',
+            b'-Subproject commit 06d0bdd9e2e20377b3180e4986b14c8549b393e4',
+            b'+Subproject commit cc975646af69f279396d4d5e1379ac6af80ee637',
             ], f.getvalue().splitlines())
 
     def test_object_diff_blob(self):
@@ -535,5 +535,5 @@ class DiffTests(TestCase):
             b'@@ -1,2 +1 @@',
             b'-new',
             b'-same',
-            b'+Submodule commit 06d0bdd9e2e20377b3180e4986b14c8549b393e4',
+            b'+Subproject commit 06d0bdd9e2e20377b3180e4986b14c8549b393e4',
             ], f.getvalue().splitlines())


### PR DESCRIPTION
When generating a diff in a repository with dirty submodules, CGit is using
the subproject terminology. I couldn't find the reasoning why or since when it
has been doing it but https://stackoverflow.com/q/4873980/2996250 seems to
indicate it has been the case since 2011 at least.

It has no real impacts as submodules information in diff are mostly ignored by
`git apply` but this makes Dulwich behavior closer to CGit one.