### PR TITLE
Fix line-ending conversion support

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -629,16 +629,27 @@ def _has_directory_changed(tree_path, entry):
     return False
 
 
-def get_unstaged_changes(index, root_path, filter_blob_callback=None):
+def get_unstaged_changes(index, repo, filter_blob_callback=None):
     """Walk through an index and check for differences against working tree.
 
     :param index: index to check
     :param root_path: path in which to find files
     :return: iterator over paths with unstaged changes
     """
+    root_path = repo.path
     # For each entry in the index check the sha1 & ensure not staged
     if not isinstance(root_path, bytes):
         root_path = root_path.encode(sys.getfilesystemencoding())
+
+    head_tree = None
+    lookup_obj = repo.object_store.__getitem__
+
+    try:
+        head_tree = repo[repo[b"HEAD"].tree]
+    except KeyError:
+        # In case we don't have a HEAD refs, the line-ending filters will
+        # be executed
+        pass
 
     for tree_path, entry in index.iteritems():
         full_path = _tree_to_fs_path(root_path, tree_path)
@@ -652,7 +663,19 @@ def get_unstaged_changes(index, root_path, filter_blob_callback=None):
             blob = blob_from_path_and_stat(full_path, st)
 
             if filter_blob_callback is not None:
-                blob = filter_blob_callback(blob, tree_path)
+
+                if not head_tree:
+                    new_file = True
+                else:
+                    try:
+                        head_tree.lookup_path(lookup_obj, tree_path)
+                        new_file = False
+                    except KeyError:
+                        # Line-ending conversion is done only for files
+                        # not in store yet
+                        new_file = True
+
+                blob = filter_blob_callback(blob, tree_path, new_file)
         except EnvironmentError as e:
             if e.errno == errno.ENOENT:
                 # The file was removed, so we assume that counts as

--- a/dulwich/line_ending.py
+++ b/dulwich/line_ending.py
@@ -31,6 +31,9 @@ The normalization is a two-fold process that happens at two moments:
   when doing a `git add` call. We call this process the write filter in this
   module.
 
+The normalization only happens when the resulting file does not exists yet.
+For the write filter, they are files that are shown as added in status.
+
 One thing to know is that Git does line-ending normalization only on text
 files. How does Git know that a file is text? We can either mark a file as a
 text file, a binary file or ask Git to automatically decides. Git has an
@@ -229,9 +232,14 @@ class BlobNormalizer(object):
             core_eol, core_autocrlf, self.gitattributes
         )
 
-    def checkin_normalize(self, blob, tree_path):
+    def checkin_normalize(self, blob, tree_path, new_file):
         """ Normalize a blob during a checkin operation
         """
+        if not new_file:
+            # Line-ending normalization only happens for new files, aka files
+            # not already commited
+            return blob
+
         if self.fallback_write_filter is not None:
             return normalize_blob(
                 blob, self.fallback_write_filter, binary_detection=True
@@ -239,9 +247,14 @@ class BlobNormalizer(object):
 
         return blob
 
-    def checkout_normalize(self, blob, tree_path):
+    def checkout_normalize(self, blob, tree_path, new_file):
         """ Normalize a blob during a checkout operation
         """
+        if not new_file:
+            # Line-ending normalization only happens for new files, aka files
+            # not already commited
+            return blob
+
         if self.fallback_read_filter is not None:
             return normalize_blob(
                 blob, self.fallback_read_filter, binary_detection=True

--- a/dulwich/line_ending.py
+++ b/dulwich/line_ending.py
@@ -232,8 +232,10 @@ class BlobNormalizer(object):
             core_eol, core_autocrlf, self.gitattributes
         )
 
-    def checkin_normalize(self, blob, tree_path, new_file):
+    def checkin_normalize(self, blob, tree_path, new_file=True):
         """ Normalize a blob during a checkin operation
+
+        new_file is set to True by default for backward-compatibility
         """
         if not new_file:
             # Line-ending normalization only happens for new files, aka files
@@ -247,8 +249,10 @@ class BlobNormalizer(object):
 
         return blob
 
-    def checkout_normalize(self, blob, tree_path, new_file):
+    def checkout_normalize(self, blob, tree_path, new_file=True):
         """ Normalize a blob during a checkout operation
+
+        new_file is set to True by default for backward-compatibility
         """
         if not new_file:
             # Line-ending normalization only happens for new files, aka files

--- a/dulwich/patch.py
+++ b/dulwich/patch.py
@@ -192,7 +192,7 @@ def write_object_diff(f, store, old_file, new_file, diff_binary=False):
         if hexsha is None:
             return Blob.from_string(b'')
         elif S_ISGITLINK(mode):
-            return Blob.from_string(b"Submodule commit " + hexsha + b"\n")
+            return Blob.from_string(b"Subproject commit " + hexsha + b"\n")
         else:
             return store[hexsha]
 

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -942,7 +942,7 @@ def status(repo=".", ignored=False):
         normalizer = r.get_blob_normalizer()
         filter_callback = normalizer.checkin_normalize
         unstaged_changes = list(
-            get_unstaged_changes(index, r.path, filter_callback)
+            get_unstaged_changes(index, r, filter_callback)
         )
         ignore_manager = IgnoreFilterManager.from_repo(r)
         untracked_paths = get_untracked_paths(r.path, r.path, index)

--- a/dulwich/tests/test_index.py
+++ b/dulwich/tests/test_index.py
@@ -645,7 +645,7 @@ class GetUnstagedChangesTests(TestCase):
             # modify access and modify time of path
             os.utime(foo1_fullpath, (0, 0))
 
-            changes = get_unstaged_changes(repo.open_index(), repo_dir)
+            changes = get_unstaged_changes(repo.open_index(), repo)
 
             self.assertEqual(list(changes), [b'foo1'])
 
@@ -667,7 +667,7 @@ class GetUnstagedChangesTests(TestCase):
 
             os.unlink(foo1_fullpath)
 
-            changes = get_unstaged_changes(repo.open_index(), repo_dir)
+            changes = get_unstaged_changes(repo.open_index(), repo)
 
             self.assertEqual(list(changes), [b'foo1'])
 
@@ -690,7 +690,7 @@ class GetUnstagedChangesTests(TestCase):
             os.remove(foo1_fullpath)
             os.mkdir(foo1_fullpath)
 
-            changes = get_unstaged_changes(repo.open_index(), repo_dir)
+            changes = get_unstaged_changes(repo.open_index(), repo)
 
             self.assertEqual(list(changes), [b'foo1'])
 
@@ -714,7 +714,7 @@ class GetUnstagedChangesTests(TestCase):
             os.remove(foo1_fullpath)
             os.symlink(os.path.dirname(foo1_fullpath), foo1_fullpath)
 
-            changes = get_unstaged_changes(repo.open_index(), repo_dir)
+            changes = get_unstaged_changes(repo.open_index(), repo)
 
             self.assertEqual(list(changes), [b'foo1'])
 

--- a/dulwich/tests/test_patch.py
+++ b/dulwich/tests/test_patch.py
@@ -363,8 +363,8 @@ class DiffTests(TestCase):
             b'--- a/asubmodule',
             b'+++ b/asubmodule',
             b'@@ -1 +1 @@',
-            b'-Submodule commit 06d0bdd9e2e20377b3180e4986b14c8549b393e4',
-            b'+Submodule commit cc975646af69f279396d4d5e1379ac6af80ee637',
+            b'-Subproject commit 06d0bdd9e2e20377b3180e4986b14c8549b393e4',
+            b'+Subproject commit cc975646af69f279396d4d5e1379ac6af80ee637',
             ], f.getvalue().splitlines())
 
     def test_object_diff_blob(self):
@@ -535,5 +535,5 @@ class DiffTests(TestCase):
             b'@@ -1,2 +1 @@',
             b'-new',
             b'-same',
-            b'+Submodule commit 06d0bdd9e2e20377b3180e4986b14c8549b393e4',
+            b'+Subproject commit 06d0bdd9e2e20377b3180e4986b14c8549b393e4',
             ], f.getvalue().splitlines())

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -1211,11 +1211,10 @@ class StatusTests(PorcelainTestCase):
         self.assertListEqual(results.untracked, [])
 
     def test_status_crlf_convert(self):
-        # With an emty repo
+        # With an empty repo
         file_path = os.path.join(self.repo.path, 'crlf')
         repo = Repo(self.repo_path)
 
-        # TODO: It should be set automatically by looking at the configuration
         c = self.repo.get_config()
         c.set("core", "autocrlf", True)
         c.write_to_path()


### PR DESCRIPTION
The first support of line-ending conversion was too aggressive. After further
manual testing and investigation of
https://github.com/dulwich/dulwich/issues/693, I realized that line-ending
conversions doesn't apply on every checkin or checkout operation, only on
checkin or checkout operation resulting in a new file being created.

CGit actually tells you when it's applying the line-ending normalization with
a message that looks like: `warning: CRLF will be replaced by LF in BRANCH2.`

It should hopefully fix #693