### PR TITLE
ci: deploy to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,18 @@ script:
 after_success:
   - python -m coverage combine
   - codecov
+
+deploy:
+  provider: pypi
+  user: dulwich-bot
+  password:
+    secure: e7DTu4CwOCARfN/mwA8lXQ==
+  skip_cleanup: true
+  skip_existing: true
+  file_glob: true
+  file:
+    - dist/dulwich*.whl
+    - dist/dulwich*.tar.gz
+  on:
+    tags: true
+    repo: dulwich/dulwich

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
 
-  PYPI_USER: "dulwich-bot"
-  PYPI_PSWD:
+  TWINE_USERNAME: "dulwich-bot"
+  TWINE_PASSWORD:
     # See https://www.appveyor.com/docs/build-configuration/#secure-variables
     secure: e7DTu4CwOCARfN/mwA8lXQ==
 
@@ -88,6 +88,10 @@ after_test:
   # - "python setup.py bdist_wininst"
   - "build.cmd %PYTHON%\\python.exe setup.py bdist_msi"
   - ps: "ls dist"
+
+deploy_script:
+  - if "%APPVEYOR_REPO_TAG%"=="true" pip install twine
+  - if "%APPVEYOR_REPO_TAG%"=="true" twine upload dist\dulwich-*.whl
 
 artifacts:
   - path: dist\*


### PR DESCRIPTION
 - [x] make travis upload source and linux wheel to pypi;

- <s> make travis upload osx wheel to pypi; </s> (tests are failing on osx, so need to sort those out first, so we don't accidentally upload something that doesn't actually work on osx properly. Out of the scope for this PR.)

 - [x] make appveyor upload windows wheel to pypi;

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>