### PR TITLE
Allow configured email addresses to be pre-quoted as "<...>".

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -34,6 +34,7 @@ import os
 import sys
 import stat
 import time
+import re
 
 from dulwich.errors import (
     NoIndexPresent,
@@ -112,6 +113,9 @@ BASE_DIRECTORIES = [
 
 DEFAULT_REF = b'refs/heads/master'
 
+quoted_email_re = re.compile(b"^\s*<\s*(.*)\s*>\s*$")
+
+
 
 class InvalidUserIdentity(Exception):
     """User identity is not of the format 'user <email>'"""
@@ -175,6 +179,9 @@ def get_user_identity(config, kind=None):
         email = default_email
         if not isinstance(email, bytes):
             email = email.encode('utf-8')
+    m = quoted_email_re.match(email)
+    if m:
+        email = m.group(1)
     return (user + b" <" + email + b">")
 
 

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -113,8 +113,7 @@ BASE_DIRECTORIES = [
 
 DEFAULT_REF = b'refs/heads/master'
 
-quoted_email_re = re.compile(b"^\s*<\s*(.*)\s*>\s*$")
-
+quoted_email_re = re.compile(br"^\s*<\s*(.*)\s*>\s*$")
 
 
 class InvalidUserIdentity(Exception):

--- a/dulwich/tests/test_repository.py
+++ b/dulwich/tests/test_repository.py
@@ -882,7 +882,7 @@ class BuildRepoRootTests(TestCase):
         r = self._repo
         c = r.get_config()
         c.set((b"user", ), b"name", b"Jelmer")
-        c.set((b"user", ), b"email", b"jelmer@apache.org")
+        c.set((b"user", ), b"email", b"<jelmer@apache.org>")
         c.write_to_path()
         commit_sha = r.do_commit(b'message')
         self.assertEqual(


### PR DESCRIPTION
While investigating RabbitVCS issue https://github.com/rabbitvcs/rabbitvcs/issues/121, I tracked the problem  down to dulwich.
This PR is a proposed fix.
Thanks for considering it.