### PR TITLE
Optimize idempotent ref file write

### DIFF
--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -717,8 +717,7 @@ class DiskRefsContainer(RefsContainer):
                 # read again while holding the lock
                 orig_ref = self.read_loose_ref(realname)
                 if orig_ref is None:
-                    orig_ref = self.get_packed_refs().get(
-                            realname, ZERO_SHA)
+                    orig_ref = self.get_packed_refs().get(realname, ZERO_SHA)
             except (OSError, IOError):
                 f.abort()
                 raise

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -721,6 +721,9 @@ class DiskRefsContainer(RefsContainer):
             except (OSError, IOError):
                 f.abort()
                 raise
+            if new_ref == orig_ref:
+                f.abort()
+                return False
             if old_ref is not None:
                 if orig_ref != old_ref:
                     f.abort()

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -713,16 +713,16 @@ class DiskRefsContainer(RefsContainer):
 
         ensure_dir_exists(os.path.dirname(filename))
         with GitFile(filename, 'wb') as f:
+            try:
+                # read again while holding the lock
+                orig_ref = self.read_loose_ref(realname)
+                if orig_ref is None:
+                    orig_ref = self.get_packed_refs().get(
+                            realname, ZERO_SHA)
+            except (OSError, IOError):
+                f.abort()
+                raise
             if old_ref is not None:
-                try:
-                    # read again while holding the lock
-                    orig_ref = self.read_loose_ref(realname)
-                    if orig_ref is None:
-                        orig_ref = self.get_packed_refs().get(
-                                realname, ZERO_SHA)
-                except (OSError, IOError):
-                    f.abort()
-                    raise
                 if orig_ref != old_ref:
                     f.abort()
                     return False

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -720,12 +720,12 @@ class DiskRefsContainer(RefsContainer):
                     if orig_ref is None:
                         orig_ref = self.get_packed_refs().get(
                                 realname, ZERO_SHA)
-                    if orig_ref != old_ref:
-                        f.abort()
-                        return False
                 except (OSError, IOError):
                     f.abort()
                     raise
+                if orig_ref != old_ref:
+                    f.abort()
+                    return False
             try:
                 f.write(new_ref + b'\n')
             except (OSError, IOError):

--- a/dulwich/tests/test_refs.py
+++ b/dulwich/tests/test_refs.py
@@ -224,8 +224,12 @@ class RefsContainerTests(object):
             b'HEAD', b'42d06bd4b77fed026b154d16493e5deab78f02ec', nines))
         self.assertEqual(nines, self._refs[b'HEAD'])
 
-        self.assertTrue(self._refs.set_if_equals(b'refs/heads/master', None,
-                                                 nines))
+        # DictRefsContainer doesn’t fully support symbolic refs and therefore
+        # the call to set_if_equals() changes the ref, while the ref is already
+        # set to the same value with DiskRefsContainer.
+        self.assertIs(
+                isinstance(self._refs, DictRefsContainer),
+                self._refs.set_if_equals(b'refs/heads/master', None, nines))
         self.assertEqual(nines, self._refs[b'refs/heads/master'])
 
         self.assertTrue(self._refs.set_if_equals(


### PR DESCRIPTION
The advantage is that it saves one `fsync()` if the content wouldn’t change.

The disadvantage is that it introduces another read from the ref file. However, the file is already read shortly before and very likely to be in the file system cache.