### PR TITLE
Handle Windows path separators

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -23,6 +23,7 @@
 import collections
 import errno
 import os
+import os.path
 import stat
 import struct
 import sys
@@ -496,7 +497,7 @@ def validate_path_element_ntfs(element):
 
 def validate_path(path, element_validator=validate_path_element_default):
     """Default path validator that just checks for .git/."""
-    parts = path.split(b"/")
+    parts = path.split(str.encode(os.path.sep))
     for p in parts:
         if not element_validator(p):
             return False

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -25,6 +25,7 @@
 from io import BytesIO
 import errno
 import os
+import os.path
 import stat
 import sys
 import tempfile
@@ -1265,7 +1266,7 @@ def commit_tree_changes(object_store, tree, changes):
     nested_changes = {}
     for (path, new_mode, new_sha) in changes:
         try:
-            (dirname, subpath) = path.split(b'/', 1)
+            (dirname, subpath) = path.split(str.encode(os.path.sep), 1)
         except ValueError:
             if new_sha is None:
                 del tree[path]

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -25,6 +25,7 @@ import binascii
 from io import BytesIO
 from collections import namedtuple
 import os
+import os.path
 import posixpath
 import stat
 import sys
@@ -1072,7 +1073,7 @@ class Tree(ShaFile):
         :param path: Path to lookup
         :return: A tuple of (mode, SHA) of the resulting path.
         """
-        parts = path.split(b'/')
+        parts = path.split(str.encode(os.path.sep))
         sha = self.id
         mode = None
         for p in parts:


### PR DESCRIPTION
This updates a few spots where assuming path separators of '/' results in the failure to find files.

Closes #727