### PR TITLE
SendPackError exceptions have no message attribute

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -917,9 +917,9 @@ def push(repo, remote_location, refspecs,
             errstream.write(
                 b"Push to " + remote_location_bytes + b" successful.\n")
         except (UpdateRefsError, SendPackError) as e:
+            message, = e.args
             errstream.write(b"Push to " + remote_location_bytes +
-                            b" failed -> " + e.message.encode(err_encoding) +
-                            b"\n")
+                            b" failed -> " + message + b"\n")
 
 
 def pull(repo, remote_location=None, refspecs=None,


### PR DESCRIPTION
The message is stored as the first element of the args attribute.