### PR TITLE
Feature: Pull remote url

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -940,9 +940,12 @@ def pull(repo, remote_location=None, refspecs=None,
     # Open the repo
     with open_repo_closing(repo) as r:
         if remote_location is None:
-            # TODO(jelmer): Lookup 'remote' for current branch in config
-            raise NotImplementedError(
-                "looking up remote from branch config not supported yet")
+            section = (b'remote', b'origin')
+            config = r.get_config()
+            if config.has_section(section):
+                url = config.get(section, 'url')
+                remote_location = url.decode()
+
         if refspecs is None:
             refspecs = [b"HEAD"]
         selected_refs = []

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -1007,6 +1007,18 @@ class PullTests(PorcelainTestCase):
         with Repo(self.target_path) as r:
             self.assertEqual(r[b'HEAD'].id, self.repo[b'HEAD'].id)
 
+    def test_no_remote_location(self):
+        outstream = BytesIO()
+        errstream = BytesIO()
+
+        # Pull changes into the cloned repo
+        porcelain.pull(self.target_path, refspecs=b'refs/heads/master',
+                       outstream=outstream, errstream=errstream)
+
+        # Check the target repo for pushed changes
+        with Repo(self.target_path) as r:
+            self.assertEqual(r[b'HEAD'].id, self.repo[b'HEAD'].id)
+
 
 class StatusTests(PorcelainTestCase):
 


### PR DESCRIPTION
Lookup remote origin url when using `porcelain.pull()`.

This should allow `porcelain.pull()` work when git repository has a remote origin defined.