### PR TITLE
Fallback to get_redirect_location() for urrlib3 versions lower than 1.23

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1603,7 +1603,13 @@ class HttpGitClient(GitClient):
         read = BytesIO(resp.data).read
 
         resp.content_type = resp.getheader("Content-Type")
-        resp_url = resp.geturl()
+        resp_url = ''
+        # Check if geturl() is available (urllib3 version >= 1.23)
+        try:
+            resp_url = resp.geturl()
+        except AttributeError:
+            # get_redirect_location() is available for urllib3 >= 1.1
+            resp_url = resp.get_redirect_location()
         resp.redirect_location = resp_url if resp_url != url else ''
 
         return resp, read

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1607,11 +1607,10 @@ class HttpGitClient(GitClient):
         # Check if geturl() is available (urllib3 version >= 1.23)
         try:
             resp_url = resp.geturl()
+            resp.redirect_location = resp_url if resp_url != url else ''
         except AttributeError:
             # get_redirect_location() is available for urllib3 >= 1.1
-            resp_url = resp.get_redirect_location()
-        resp.redirect_location = resp_url if resp_url != url else ''
-
+            resp.redirect_location = resp.get_redirect_location()
         return resp, read
 
     def _discover_references(self, service, base_url):


### PR DESCRIPTION
``geturl()`` was introduced for ***HTTPResponse*** in versions 1.23 of ***urllib3***.
This PR will allow a fallback to ``get_redirect_location()`` for earlier *urllib3* versions.

Reason: We would like the *QGIS Resource Sharing* plugin to include a recent release of dulwich.
It enables resource sharing in QGIS, and should work for the most popular platforms, including Ubuntu 18.04 (Bionic) that ships with *urrlib3* version 1.22.1 (https://packages.ubuntu.com/bionic/python3-urllib3).

See also #702 (``Python error when cloning: AttributeError: 'HTTPResponse' object has no attribute 'geturl'``)

Backporting should be fine, but I don't know if it is relevant.