### PR TITLE
Incorrect reading of a packet line

### DIFF
--- a/dulwich/protocol.py
+++ b/dulwich/protocol.py
@@ -213,7 +213,14 @@ class Protocol(object):
                 return None
             if self.report_activity:
                 self.report_activity(size, 'read')
-            pkt_contents = read(size-4)
+            have_to_read = size-4
+            pkt_contents = bytes()
+            while have_to_read > 0:
+                contens = read(have_to_read)
+                if not contens:
+                    break
+                have_to_read -= len(contens)
+                pkt_contents += contens
         except socket.error as e:
             raise GitProtocolError(e)
         else:


### PR DESCRIPTION
During ssh cloning of repository you can get this error:
```
$ dulwich clone ssh://server/reponame
Counting objects: 134, done.
Compressing objects: 100% (91/91), done.
Total 134 (delta 49), reused 71 (delta 10)
Traceback (most recent call last):
  File "/home/lanedis/.local/bin/dulwich", line 716, in <module>
    cmd_kls().run(sys.argv[2:])
  File "/home/lanedis/.local/bin/dulwich", line 244, in run
    porcelain.clone(source, target, bare=options.bare, depth=options.depth)
  File "/home/lanedis/.local/lib/python3.8/site-packages/dulwich/porcelain.py", line 363, in clone
    fetch_result = fetch(
  File "/home/lanedis/.local/lib/python3.8/site-packages/dulwich/porcelain.py", line 1288, in fetch
    fetch_result = client.fetch(path, r, progress=errstream.write,
  File "/home/lanedis/.local/lib/python3.8/site-packages/dulwich/client.py", line 422, in fetch
    result = self.fetch_pack(
  File "/home/lanedis/.local/lib/python3.8/site-packages/dulwich/client.py", line 903, in fetch_pack
    self._handle_upload_pack_tail(
  File "/home/lanedis/.local/lib/python3.8/site-packages/dulwich/client.py", line 710, in _handle_upload_pack_tail
    self._read_side_band64k_data(proto, {
  File "/home/lanedis/.local/lib/python3.8/site-packages/dulwich/client.py", line 511, in _read_side_band64k_data
    for pkt in proto.read_pkt_seq():
  File "/home/lanedis/.local/lib/python3.8/site-packages/dulwich/protocol.py", line 275, in read_pkt_seq
    pkt = self.read_pkt_line()
  File "/home/lanedis/.local/lib/python3.8/site-packages/dulwich/protocol.py", line 231, in read_pkt_line
    raise GitProtocolError(
dulwich.errors.GitProtocolError: Length of pkt read 0005 does not match length prefix 2005
```
That happens because of the incorrect using of `read(size)` function, according docs (https://docs.python.org/3/library/io.html):
```
Read up to size bytes from the object and return them. As a convenience, if size is unspecified or -1, all bytes until EOF are returned. Otherwise, only one system call is ever made.
```
> only one system call is ever made

So in some cases we have to read multiple times to get desired read buffer size