### PR TITLE
Coding problem

### DIFF
--- a/dulwich/patch.py
+++ b/dulwich/patch.py
@@ -117,15 +117,15 @@ def unified_diff(a, b, fromfile='', tofile='', fromfiledate='',
             fromdate = '\t{}'.format(fromfiledate) if fromfiledate else ''
             todate = '\t{}'.format(tofiledate) if tofiledate else ''
             yield '--- {}{}{}'.format(
-                fromfile.decode("ascii"),
+                fromfile.decode("utf8"),
                 fromdate,
                 lineterm
-                ).encode('ascii')
+                ).encode('utf8')
             yield '+++ {}{}{}'.format(
-                tofile.decode("ascii"),
+                tofile.decode("utf8"),
                 todate,
                 lineterm
-                ).encode('ascii')
+                ).encode('utf8')
 
         first, last = group[0], group[-1]
         file1_range = _format_range_unified(first[1], last[2])
@@ -134,7 +134,7 @@ def unified_diff(a, b, fromfile='', tofile='', fromfiledate='',
             file1_range,
             file2_range,
             lineterm
-             ).encode('ascii')
+             ).encode('utf8')
 
         for tag, i1, i2, j1, j2 in group:
             if tag == 'equal':


### PR DESCRIPTION
To solve the `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe9 
in position 27: ordinal not in range (128)` problem, change `ascii` to` 
utf8`.

Before modification.

![2020-05-21 10-57-27 的螢幕擷圖](https://user-images.githubusercontent.com/38396747/82518778-b1c01300-9b52-11ea-8b53-88dc95275029.png)

After modification.

![2020-05-21 10-57-55 的螢幕擷圖](https://user-images.githubusercontent.com/38396747/82518786-b71d5d80-9b52-11ea-8bfa-894f62bc618b.png)

If it is determined that this is the solution, please let it merge, because the company cannot pass the CI check because of this error.

Issue 763