### PR TITLE
fix command-line parsing for cli.py

### DIFF
--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -721,7 +721,7 @@ def main(argv=None):
         print("No such subcommand: %s" % cmd)
         return 1
     # TODO(jelmer): Return non-0 on errors
-    return cmd_kls().run(sys.argv[1:])
+    return cmd_kls().run(sys.argv[2:])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Only the arguments of the subcommand (i.e dulwich clone ...) should be passed to the function, not the subcommand itself as well:
(continuing the example) 'github.com/dulwich/dulwich.git', not 'clone github.com/dulwich/dulwich.git'