### PR TITLE
Add python_requires metadata to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ if has_setuptools:
         "console_scripts": [
             "dulwich=dulwich.cli:main",
         ]}
+    setup_kwargs['python_requires'] = '>=3.5'
 else:
     scripts.append('bin/dulwich')
 


### PR DESCRIPTION
If trying to install dulwich on Python 2, the following error will be printed:
"ERROR: Package 'dulwich' requires a different Python: 2.7.18 not in '>=3.5'"