### PR TITLE
Use chain.from_iterable in diff_tree.py

### DIFF
--- a/dulwich/diff_tree.py
+++ b/dulwich/diff_tree.py
@@ -314,7 +314,7 @@ def _count_blocks(obj):
     block_truncate = block.truncate
     block_getvalue = block.getvalue
 
-    for c in chain(*obj.as_raw_chunks()):
+    for c in chain.from_iterable(obj.as_raw_chunks()):
         c = c.to_bytes(1, 'big')
         block_write(c)
         n += 1


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.