### PR TITLE
Use chain.from_iterable in compat/test_repository.py

### DIFF
--- a/dulwich/tests/compat/test_repository.py
+++ b/dulwich/tests/compat/test_repository.py
@@ -117,8 +117,10 @@ class ObjectStoreTestCase(CompatTestCase):
 
     def test_packed_objects(self):
         expected_shas = self._get_all_shas() - self._get_loose_shas()
-        self.assertShasMatch(expected_shas,
-                             chain(*self._repo.object_store.packs))
+        self.assertShasMatch(
+            expected_shas,
+            chain.from_iterable(self._repo.object_store.packs)
+        )
 
     def test_all_objects(self):
         expected_shas = self._get_all_shas()


### PR DESCRIPTION
This is a continuation of #778 . I don't know whether this file is important enough for this change, given it's a test file in the compat package. Your call.