### PR TITLE
Allow "ACK" and "NACK" (without new line) in client.py

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -969,9 +969,9 @@ class TraditionalGitClient(GitClient):
                 pkt = proto.read_pkt_line()
             except HangupException:
                 raise _remote_error_from_stderr(stderr)
-            if pkt == b"NACK\n":
+            if pkt == b"NACK\n" or pkt == b"NACK":
                 return
-            elif pkt == b"ACK\n":
+            elif pkt == b"ACK\n" or pkt == b"ACK":
                 pass
             elif pkt.startswith(b"ERR "):
                 raise GitProtocolError(


### PR DESCRIPTION
While working in my own environment the archive was failing for me
with "invalid response ACK" message". Looks like my git (hosted gerrit)
returns ACK instead of "ACK\n" expected by that code. As the shell
git clients works well with my server, seems like both versions should be
supported by the library.

I've tested it locally with my hosted git.

Fixes #805