### PR TITLE
gha: move linux wheels to wheelhouse dir

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -55,6 +55,8 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
+        mkdir wheelhouse
+        mv dist/*.whl wheelhouse
         twine upload wheelhouse/*manylinux*
       if: "matrix.os == 'ubuntu-latest'"
     - name: Publish


### PR DESCRIPTION
Just following the convention for wheel location. Clearly the workflow
file needs some refactoring, but it is out of scope for this particular PR.