### PR TITLE
Fix minor stash bugs

### DIFF
--- a/dulwich/stash.py
+++ b/dulwich/stash.py
@@ -47,7 +47,7 @@ class Stash(object):
 
     def stashes(self):
         reflog_path = os.path.join(
-            self._repo.commondir(), 'logs', self._ref)
+            self._repo.commondir(), 'logs', os.fsdecode(self._ref))
         try:
             with GitFile(reflog_path, 'rb') as f:
                 return reversed(list(read_reflog(f)))
@@ -93,7 +93,7 @@ class Stash(object):
         stash_tree_id = commit_tree(
                 self._repo.object_store,
                 iter_fresh_objects(
-                    index, self._repo.path,
+                    index, os.fsencode(self._repo.path),
                     object_store=self._repo.object_store))
 
         if message is None:

--- a/dulwich/stash.py
+++ b/dulwich/stash.py
@@ -111,7 +111,7 @@ class Stash(object):
         return cid
 
     def __getitem__(self, index):
-        return self._stashes()[index]
+        return list(self.stashes())[index]
 
     def __len__(self):
         return len(self._stashes())

--- a/dulwich/stash.py
+++ b/dulwich/stash.py
@@ -114,4 +114,4 @@ class Stash(object):
         return list(self.stashes())[index]
 
     def __len__(self):
-        return len(self._stashes())
+        return len(list(self.stashes()))


### PR DESCRIPTION
Fixes minor bugs in `stash.Stash`

* use `os.fsencode`/`os.fsdecode` when needed so that bytes/strings are not mixed
* make `__getitem__` and `__len__` work properly (use `list(stashes())` instead of `_stashes()`)