### PR TITLE
Fix for byte problems (TypeError) reading alternate paths 

### DIFF
--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -582,7 +582,8 @@ class DiskObjectStore(PackBasedObjectStore):
                 if os.path.isabs(line):
                     yield os.fsdecode(line)
                 else:
-                    yield os.fsdecode(os.path.join(self.path, line))
+                    yield os.fsdecode(os.path.join(os.fsencode(self.path),
+                                                   line))
 
     def add_alternate_path(self, path):
         """Add an alternate path to this object store.

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -577,7 +577,7 @@ class DiskObjectStore(PackBasedObjectStore):
         with f:
             for line in f.readlines():
                 line = line.rstrip(b"\n")
-                if line[0] == b"#":
+                if line.startswith(b"#"):
                     continue
                 if os.path.isabs(line):
                     yield os.fsdecode(line)

--- a/dulwich/tests/test_object_store.py
+++ b/dulwich/tests/test_object_store.py
@@ -370,6 +370,10 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
         store.add_alternate_path(abs_path)
         self.assertEqual(set(store._read_alternate_paths()), {abs_path})
 
+        store.add_alternate_path("relative-path")
+        self.assertIn(os.path.join(store.path, "relative-path"),
+                      set(store._read_alternate_paths()))
+
     def test_corrupted_object_raise_exception(self):
         """Corrupted sha1 disk file should raise specific exception"""
         self.store.add_object(testobject)

--- a/dulwich/tests/test_object_store.py
+++ b/dulwich/tests/test_object_store.py
@@ -374,6 +374,12 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
         self.assertIn(os.path.join(store.path, "relative-path"),
                       set(store._read_alternate_paths()))
 
+        # arguably, add_alternate_path() could strip comments.
+        # Meanwhile it's more convenient to use it than to import INFODIR
+        store.add_alternate_path("# comment")
+        for alt_path in store._read_alternate_paths():
+            self.assertNotIn("#", alt_path)
+
     def test_corrupted_object_raise_exception(self):
         """Corrupted sha1 disk file should raise specific exception"""
         self.store.add_object(testobject)

--- a/dulwich/tests/test_object_store.py
+++ b/dulwich/tests/test_object_store.py
@@ -362,6 +362,14 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
         self.assertIn(b2.id, store)
         self.assertEqual(b2, store[b2.id])
 
+    def test_read_alternate_paths(self):
+        store = DiskObjectStore(self.store_dir)
+
+        abs_path = os.path.abspath(os.path.normpath('/abspath'))
+        # ensures in particular existence of the alternates file
+        store.add_alternate_path(abs_path)
+        self.assertEqual(set(store._read_alternate_paths()), {abs_path})
+
     def test_corrupted_object_raise_exception(self):
         """Corrupted sha1 disk file should raise specific exception"""
         self.store.add_object(testobject)


### PR DESCRIPTION
On Python 3, dulwich crashes with `TypeError` if there is a relative path in `info/alternates`.

This PR reproduces and fixes the problem in tests, and also an issue with comments uncovered while investigating my actual issue.

For more context, here's the [issue reported by one of my users](https://foss.heptapod.net/heptapod/heptapod/-/issues/370). Happens in GitLab because  the path to pool is relative.

Since this is I believe my first contribution to Dulwich, do you want an issue to supplement that?