### PR TITLE
upload sdist

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -58,6 +58,8 @@ jobs:
         # Only include *manylinux* wheels; the other wheels files are built but
         # rejected by pip.
         twine upload dist/*manylinux*.whl
+        # also upload sdist
+        twine upload dist/*tar.gz
       if: "matrix.os == 'ubuntu-latest'"
     - name: Publish
       env:


### PR DESCRIPTION
Uploads the sdist to PyPI, not just wheels. 

Fixes https://github.com/dulwich/dulwich/issues/816