### PR TITLE
Issue 793: Fix failure in get_untracked_paths when the repository contains symlinks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+0.20.16	2021-01-16
+
+ * Add flag to only attempt to fetch ignored untracked files when specifically requested.
+   (Matt Seddon)
+
 0.20.15	2020-12-23
 
  * Add some functions for parsing and writing bundles.

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -1158,6 +1158,7 @@ def get_untracked_paths(frompath, basepath, index, exclude_ignored=False):
     ;param frompath: Path to walk
       basepath: Path to compare to
       index: Index to check against
+      exclude_ignored: Whether to exclude ignored paths
     """
     ignore_manager = _get_ignore_manager(frompath, exclude_ignored)
 
@@ -1172,6 +1173,12 @@ def get_untracked_paths(frompath, basepath, index, exclude_ignored=False):
 
 
 def _get_ignore_manager(frompath, exclude_ignored):
+    """Get a repo's IgnoreFilterManager from a path if required.
+
+    Args:
+    ;param frompath: The path of the repo
+      exclude_ignored: Whether to return the IgnoreFilterManager
+    """
     if exclude_ignored:
         with open_repo_closing(frompath) as r:
             ignore_manager = IgnoreFilterManager.from_repo(r)

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -1118,7 +1118,8 @@ def status(repo=".", ignored=False):
             get_unstaged_changes(index, r.path, filter_callback)
         )
 
-        untracked_paths = get_untracked_paths(r.path, r.path, index, exclude_ignored = not ignored)
+        untracked_paths = get_untracked_paths(r.path, r.path, index,
+                                              exclude_ignored=not ignored)
         untracked_changes = list(untracked_paths)
 
         return GitStatus(tracked_changes, unstaged_changes, untracked_changes)
@@ -1158,11 +1159,11 @@ def get_untracked_paths(frompath, basepath, index, exclude_ignored=False):
       basepath: Path to compare to
       index: Index to check against
     """
-    ignore_manager = _get_ignore_manager(frompath,exclude_ignored)
-    
+    ignore_manager = _get_ignore_manager(frompath, exclude_ignored)
+
     for ap, is_dir in _walk_working_dir_paths(frompath, basepath):
-        if (exclude_ignored
-            and ignore_manager.is_ignored(os.path.relpath(ap,frompath))):
+        if (exclude_ignored and
+                ignore_manager.is_ignored(os.path.relpath(ap, frompath))):
             continue
         if not is_dir:
             ip = path_to_tree_path(basepath, ap)

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -1466,7 +1466,9 @@ class StatusTests(PorcelainTestCase):
             set(porcelain.get_untracked_paths(subrepo.path, subrepo.path,
                                               subrepo.open_index())))
         self.assertEqual(
-            set(['nested/ignored', 'nested/with', 'nested/manager']),
+            set([os.path.join('nested', 'ignored'),
+                os.path.join('nested', 'with'),
+                os.path.join('nested', 'manager')]),
             set(porcelain.get_untracked_paths(self.repo.path, subrepo.path,
                                               self.repo.open_index(),
                                               exclude_ignored=False)))

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -20,7 +20,6 @@
 
 """Tests for dulwich.porcelain."""
 
-from dulwich.ignore import IgnoreFilterManager
 from io import BytesIO, StringIO
 import os
 import re
@@ -1454,26 +1453,28 @@ class StatusTests(PorcelainTestCase):
         with open(os.path.join(subrepo.path, 'ignored'), 'w') as f:
             f.write('bleep\n')
         with open(os.path.join(subrepo.path, 'with'), 'w') as f:
-            f.write('bloop\n')            
+            f.write('bloop\n')
         with open(os.path.join(subrepo.path, 'manager'), 'w') as f:
             f.write('blop\n')
 
         self.assertEqual(
-            set(['.gitignore','notignored']),
+            set(['.gitignore', 'notignored']),
             set(porcelain.get_untracked_paths(self.repo.path, self.repo.path,
                                               self.repo.open_index())))
         self.assertEqual(
-            set(['ignored','with', 'manager']),
+            set(['ignored', 'with', 'manager']),
             set(porcelain.get_untracked_paths(subrepo.path, subrepo.path,
-                                              subrepo.open_index())))                                          
+                                              subrepo.open_index())))
         self.assertEqual(
-            set(['nested/ignored','nested/with','nested/manager']),
+            set(['nested/ignored', 'nested/with', 'nested/manager']),
             set(porcelain.get_untracked_paths(self.repo.path, subrepo.path,
-                                              self.repo.open_index(),exclude_ignored=False)))
+                                              self.repo.open_index(),
+                                              exclude_ignored=False)))
         self.assertEqual(
             set([]),
             set(porcelain.get_untracked_paths(self.repo.path, subrepo.path,
-                                              self.repo.open_index(),exclude_ignored=True)))
+                                              self.repo.open_index(),
+                                              exclude_ignored=True)))
 
 
 # TODO(jelmer): Add test for dulwich.porcelain.daemon


### PR DESCRIPTION
As per this issue: https://github.com/dulwich/dulwich/issues/793 `porcelain.status` fails if the repo you are interrogating contains any symlinks. This generally means that the functionality will not work inside any `virtualenv`s.

In this PR I've added a flag to `get_untracked_paths` to avoid ignored symlinks and fix the above issue. 
I have added some new tests and also an entry to the NEWS (although not sure how good it is!).

Please let me know if you have any questions or concerns. All feedback is greatly appreciated.

Thanks,
Matt