### PR TITLE
client/credentials: ignore end-of-line character

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1924,7 +1924,7 @@ def get_credentials_from_store(scheme, hostname, username=None,
         try:
             with open(fname, 'rb') as f:
                 for line in f:
-                    parsed_line = urlparse(line)
+                    parsed_line = urlparse(line.strip())
                     if (parsed_line.scheme == scheme and
                             parsed_line.hostname == hostname and
                             (username is None or

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -1336,7 +1336,7 @@ class GitCredentialStoreTests(TestCase):
     @classmethod
     def setUpClass(cls):
         with tempfile.NamedTemporaryFile(delete=False) as f:
-            f.write(b'https://user:pass@example.org')
+            f.write(b'https://user:pass@example.org\n')
         cls.fname = f.name
 
     @classmethod


### PR DESCRIPTION
Before this change, credential files consisting of only one
line without end-of-line would work.

The change is actually stripping any leading and trailing whitespace,
but that shouldn't be a problem. The shared test setup is updated with
a newline because that should be a fairly common case.