### PR TITLE
Fix find_matching to stop returning after the first match

### DIFF
--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -328,8 +328,6 @@ class IgnoreFilterManager(object):
     def find_matching(self, path: str) -> Iterable[Pattern]:
         """Find matching patterns for path.
 
-        Stops after the first ignore file with matches.
-
         Args:
           path: Path to check
         Returns:
@@ -341,6 +339,7 @@ class IgnoreFilterManager(object):
         if os.path.sep != "/":
             path = path.replace(os.path.sep, "/")
         parts = path.split("/")
+        matches = []
         for i in range(len(parts) + 1):
             dirname = "/".join(parts[:i])
             for s, f in filters:
@@ -349,13 +348,11 @@ class IgnoreFilterManager(object):
                     # Paths leading up to the final part are all directories,
                     # so need a trailing slash.
                     relpath += "/"
-                matches = list(f.find_matching(relpath))
-                if matches:
-                    return iter(matches)
+                matches += list(f.find_matching(relpath))
             ignore_filter = self._load_path(dirname)
             if ignore_filter is not None:
                 filters.insert(0, (i, ignore_filter))
-        return iter([])
+        return iter(matches)
 
     def is_ignored(self, path: str) -> Optional[bool]:
         """Check whether a path is explicitly included or excluded in ignores.

--- a/dulwich/tests/test_ignore.py
+++ b/dulwich/tests/test_ignore.py
@@ -225,7 +225,6 @@ class IgnoreFilterManagerTests(TestCase):
         self.assertTrue(m.is_ignored("dir3/"))
         self.assertTrue(m.is_ignored("dir3/bla"))
 
-    @unittest.expectedFailure
     def test_nested_gitignores(self):
         tmp_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp_dir)

--- a/dulwich/tests/test_ignore.py
+++ b/dulwich/tests/test_ignore.py
@@ -25,7 +25,6 @@ import os
 import re
 import shutil
 import tempfile
-import unittest
 from dulwich.tests import TestCase
 
 from dulwich.ignore import (


### PR DESCRIPTION
This PR should fix #836
Tests are passing but what was the reason for `find_matching` to stop after the first match?