### PR TITLE
stash: skip pre-commit hooks when generating stash commits

### DIFF
--- a/dulwich/stash.py
+++ b/dulwich/stash.py
@@ -99,6 +99,7 @@ class Stash(object):
             tree=index_tree_id,
             message=b"Index stash",
             merge_heads=[self._repo.head()],
+            no_verify=True,
             **commit_kwargs
         )
 
@@ -123,6 +124,7 @@ class Stash(object):
             tree=stash_tree_id,
             message=message,
             merge_heads=[index_commit_id],
+            no_verify=True,
             **commit_kwargs
         )
 


### PR DESCRIPTION
Currently, if a repo has pre-commit hooks and any of them fail, `stash.push` will also fail (even though the types of changes you would stash in typical use cases would likely be expected to fail any pre-commit hooks)

- `stash.push` now uses `do_commit(no_verify=False, ...)` to skip running any pre-commit hooks