### PR TITLE
post-receive hook: fix an exception when the command fails with an error

### DIFF
--- a/dulwich/hooks.py
+++ b/dulwich/hooks.py
@@ -200,7 +200,7 @@ class PostReceiveShellHook(ShellHook):
             if (p.returncode != 0) or err_data:
                 err_fmt = "post-receive exit code: %d\n" + "stdout:\n%s\nstderr:\n%s"
                 err_msg = err_fmt % (p.returncode, out_data, err_data)
-                raise HookError(err_msg)
+                raise HookError(err_msg.decode('utf-8', 'backslashreplace'))
             return out_data
         except OSError as err:
             raise HookError(repr(err))

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -1038,7 +1038,7 @@ class ReceivePackHandler(PackHandler):
             if output:
                 self.proto.write_sideband(SIDE_BAND_CHANNEL_PROGRESS, output)
         except HookError as err:
-            self.proto.write_sideband(SIDE_BAND_CHANNEL_FATAL, repr(err))
+            self.proto.write_sideband(SIDE_BAND_CHANNEL_FATAL, str(err).encode('utf-8'))
 
     def handle(self) -> None:
         if self.advertise_refs or not self.stateless_rpc:


### PR DESCRIPTION
Problem:
1) self.proto.write_sideband is expecting "bytes", but was getting a "str".
2) HookError(x) expects a string for a nicer output.

Solution:
Pass a str to HookError (decode the command output),
and then pass bytes to write_sideband (encode it).