### PR TITLE
porcelain.status: skip traversal of gitignore untracked dirs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,11 @@
  * Fix filename: MERGE_HEADS => MERGE_HEAD.
    (Jelmer Vernooĳ, #861)
 
+ * For ignored directories, porcelain.add and porcelain.status now only return
+   the path to directory itself in the list of ignored paths. Previously, paths
+   for all files within the directory would also be included in the list.
+   (Peter Rowlands, #853)
+
 0.20.21	2021-03-20
 
  * Add basic support for a GcsObjectStore that stores

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -1265,7 +1265,7 @@ def get_untracked_paths(frompath, basepath, index, exclude_ignored=False):
 
     def prune_dirnames(dirpath, dirnames):
         if ignore_manager is not None:
-            path = os.path.relpath(dirpath, frompath)
+            path = os.path.join(os.path.relpath(dirpath, frompath), "")
             if ignore_manager.is_ignored(path):
                 return []
         return dirnames


### PR DESCRIPTION
When using `porcelain.get_untracked_paths` with `exclude_ignored`, currently every untracked path is checked to see if it is gitignored. If a directory is gitignored, we can skip checking the remainder of the files inside that directory - from the documentation for [gitignore](https://git-scm.com/docs/gitignore):

> Git doesn’t list excluded directories for performance reasons, so any patterns on contained files have no effect, no matter where they are defined.

Changes after this PR:

- `porcelain.get_untracked_files`: no longer walks ignored directories for performance reasons. The path to the ignored dir (including trailing slash) will be yielded if `exclude_ignored=False`, but individual files within the directory will not be included.
- `porcelain.add`: now only returns path to ignored directory in the (`added`, `ignored`) tuple (previously all files inside ignored dirs would be returned)
- `porcelain.status`: now only returns path to ignored directory when called with `ignored=True` (previously all files inside ignored dirs would be returned)