### PR TITLE
Fix two bugs in signed tag support and add ability to specify a key id to use for signing

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,7 +35,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y libgpgme-dev libgpg-error-dev
       if: "matrix.os == 'ubuntu-latest'"
     - name: Install native dependencies (MacOS)
-      run: brew install gpgme
+      run: brew install swig gpgme
       if: "matrix.os == 'macos-latest'"
     - name: Install dependencies
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install native dependencies (Ubuntu)
-      run: apt update && apt install -y libgpgme libgpg-error-dev
+      run: sudo apt-get update && sudo apt-get install -y libgpgme libgpg-error-dev
       if: "matrix.os == 'ubuntu-latest'"
     - name: Install native dependencies (MacOS)
       run: brew install gpgme

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,6 +31,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install native dependencies (Ubuntu)
+      run: apt update && apt install -y libgpgme libgpg-error-dev
+      if: "matrix.os == 'ubuntu-latest'"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Install native dependencies (Ubuntu)
       run: apt update && apt install -y libgpgme libgpg-error-dev
       if: "matrix.os == 'ubuntu-latest'"
+    - name: Install native dependencies (MacOS)
+      run: brew install gpgme
+      if: "matrix.os == 'macos-latest'"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U pip coverage codecov flake8 fastimport
+        pip install -U pip coverage codecov flake8 fastimport gpg
     - name: Install mypy
       run: |
         pip install -U mypy

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -40,7 +40,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U pip coverage codecov flake8 fastimport gpg
+        pip install -U pip coverage codecov flake8 fastimport
+    - name: Install gpg on supported platforms
+      run: pip install -U gpg
+      if: "matrix.os != 'windows-latest' && matrix.python-version != 'pypy3'"
     - name: Install mypy
       run: |
         pip install -U mypy

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install native dependencies (Ubuntu)
-      run: sudo apt-get update && sudo apt-get install -y libgpgme libgpg-error-dev
+      run: sudo apt-get update && sudo apt-get install -y libgpgme-dev libgpg-error-dev
       if: "matrix.os == 'ubuntu-latest'"
     - name: Install native dependencies (MacOS)
       run: brew install gpgme

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -796,6 +796,7 @@ class Tag(ShaFile):
             chunks.append(b"\n")  # To close headers
             chunks.append(self._message)
         if self._signature is not None:
+            chunks.append(b'\n')
             chunks.append(self._signature)
         return chunks
 

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -795,7 +795,7 @@ class Tag(ShaFile):
         if self._message is not None:
             chunks.append(b"\n")  # To close headers
             chunks.append(self._message)
-            chunks.append(b'\n')
+            chunks.append(b"\n")
         if self._signature is not None:
             chunks.append(self._signature)
         return chunks

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -795,7 +795,6 @@ class Tag(ShaFile):
         if self._message is not None:
             chunks.append(b"\n")  # To close headers
             chunks.append(self._message)
-            chunks.append(b"\n")
         if self._signature is not None:
             chunks.append(self._signature)
         return chunks

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -795,8 +795,8 @@ class Tag(ShaFile):
         if self._message is not None:
             chunks.append(b"\n")  # To close headers
             chunks.append(self._message)
-        if self._signature is not None:
             chunks.append(b'\n')
+        if self._signature is not None:
             chunks.append(self._signature)
         return chunks
 

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -950,15 +950,18 @@ def tag_create(
             tag_obj.tag_timezone = tag_timezone
             if sign:
                 import gpg
-                c = gpg.Context(armor=True)
-                if isinstance(sign, str):
-                    key = c.get_key(sign)
-                    ctx = gpg.Context(armor=True, signers=[key])
-                    tag_obj.signature, unused_result = ctx.sign(
-                        tag_obj.as_raw_string(), mode=gpg.constants.sig.mode.DETACH)
-                else:
-                    tag_obj.signature, unused_result = c.sign(
-                        tag_obj.as_raw_string(), mode=gpg.constants.sig.mode.DETACH)
+                with gpg.Context(armor=True) as c:
+                    if isinstance(sign, str):
+                        key = c.get_key(sign)
+                        with gpg.Context(armor=True, signers=[key]) as ctx:
+                            tag_obj.signature, unused_result = ctx.sign(
+                                tag_obj.as_raw_string(),
+                                mode=gpg.constants.sig.mode.DETACH,
+                            )
+                    else:
+                        tag_obj.signature, unused_result = c.sign(
+                            tag_obj.as_raw_string(), mode=gpg.constants.sig.mode.DETACH
+                        )
 
             r.object_store.add_object(tag_obj)
             tag_id = tag_obj.id

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -697,7 +697,7 @@ def print_tag(tag, decode, outstream=sys.stdout):
     timezone_str = format_timezone(tag.tag_timezone).decode("ascii")
     outstream.write("Date:   " + time_str + " " + timezone_str + "\n")
     outstream.write("\n")
-    outstream.write(decode(tag.message) + "\n")
+    outstream.write(decode(tag.message))
     outstream.write("\n")
 
 
@@ -938,7 +938,7 @@ def tag_create(
                 # TODO(jelmer): Don't use repo private method.
                 author = r._get_user_identity(r.get_config_stack())
             tag_obj.tagger = author
-            tag_obj.message = message
+            tag_obj.message = message + "\n".encode()
             tag_obj.name = tag
             tag_obj.object = (type(object), object.id)
             if tag_time is None:

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -923,7 +923,7 @@ def tag_create(
       objectish: object the tag should point at, defaults to HEAD
       tag_time: Optional time for annotated tag
       tag_timezone: Optional timezone for annotated tag
-      sign: GPG Sign the tag
+      sign: GPG Sign the tag (bool, defaults to True to use default GPG key, str with Key ID to use a specific GPG key)
     """
 
     with open_repo_closing(repo) as r:

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -950,13 +950,16 @@ def tag_create(
             tag_obj.tag_timezone = tag_timezone
             if sign:
                 import gpg
+                c = gpg.Context(armor=True)
                 if isinstance(sign, str):
-                    c = gpg.Context(armor=True, signers=[sign])
-                else:
-                    c = gpg.Context(armor=True)
-                with c:
-                    tag_obj.signature, unused_result = c.sign(
+                    key = c.get_key(sign)
+                    ctx = gpg.Context(armor=True, signers=[key])
+                    tag_obj.signature, unused_result = ctx.sign(
                         tag_obj.as_raw_string())
+                else:
+                    tag_obj.signature, unused_result = ctx.sign(
+                        tag_obj.as_raw_string())
+
             r.object_store.add_object(tag_obj)
             tag_id = tag_obj.id
         else:

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -923,8 +923,9 @@ def tag_create(
       objectish: object the tag should point at, defaults to HEAD
       tag_time: Optional time for annotated tag
       tag_timezone: Optional timezone for annotated tag
-      sign: GPG Sign the tag (bool, defaults to True to use default GPG key,
-        str with Key ID to use a specific GPG key)
+      sign: GPG Sign the tag (bool, defaults to False,
+        pass True to use default GPG key,
+        pass a str containing Key ID to use a specific GPG key)
     """
 
     with open_repo_closing(repo) as r:

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -955,10 +955,10 @@ def tag_create(
                     key = c.get_key(sign)
                     ctx = gpg.Context(armor=True, signers=[key])
                     tag_obj.signature, unused_result = ctx.sign(
-                        tag_obj.as_raw_string())
+                        tag_obj.as_raw_string(), mode=gpg.constants.sig.mode.DETACH)
                 else:
                     tag_obj.signature, unused_result = c.sign(
-                        tag_obj.as_raw_string())
+                        tag_obj.as_raw_string(), mode=gpg.constants.sig.mode.DETACH)
 
             r.object_store.add_object(tag_obj)
             tag_id = tag_obj.id

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -923,7 +923,8 @@ def tag_create(
       objectish: object the tag should point at, defaults to HEAD
       tag_time: Optional time for annotated tag
       tag_timezone: Optional timezone for annotated tag
-      sign: GPG Sign the tag (bool, defaults to True to use default GPG key, str with Key ID to use a specific GPG key)
+      sign: GPG Sign the tag (bool, defaults to True to use default GPG key,
+        str with Key ID to use a specific GPG key)
     """
 
     with open_repo_closing(repo) as r:

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -957,7 +957,7 @@ def tag_create(
                     tag_obj.signature, unused_result = ctx.sign(
                         tag_obj.as_raw_string())
                 else:
-                    tag_obj.signature, unused_result = ctx.sign(
+                    tag_obj.signature, unused_result = c.sign(
                         tag_obj.as_raw_string())
 
             r.object_store.add_object(tag_obj)

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -950,9 +950,13 @@ def tag_create(
             tag_obj.tag_timezone = tag_timezone
             if sign:
                 import gpg
-
-                with gpg.Context(armor=True) as c:
-                    tag_obj.signature, unused_result = c.sign(tag_obj.as_raw_string())
+                if isinstance(sign, str):
+                    c = gpg.Context(armor=True, signers=[sign])
+                else:
+                    c = gpg.Context(armor=True)
+                with c:
+                    tag_obj.signature, unused_result = c.sign(
+                        tag_obj.as_raw_string())
             r.object_store.add_object(tag_obj)
             tag_id = tag_obj.id
         else:

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -74,6 +74,7 @@ class PorcelainTestCase(TestCase):
         self.repo = Repo.init(self.repo_path, mkdir=True)
         self.addCleanup(self.repo.close)
 
+
 class PorcelainGpgTestCase(PorcelainTestCase):
     DEFAULT_KEY = """
 -----BEGIN PGP PRIVATE KEY BLOCK-----
@@ -159,7 +160,7 @@ BcZYEcqkDeW64mdTo65ILOPQ+HMCK12AnnBsbyfbsWAUczkQ7GVq
 -----END PGP PRIVATE KEY BLOCK-----
     """
 
-    DEFAULT_KEY_ID = '8EB47C310E1F24AE383D832F7CDD800A52E65E26'
+    DEFAULT_KEY_ID = "8EB47C310E1F24AE383D832F7CDD800A52E65E26"
 
     NON_DEFAULT_KEY = """
 -----BEGIN PGP PRIVATE KEY BLOCK-----
@@ -245,7 +246,7 @@ AanKpb2pqswnk1CVhAzh+l7JhOR5RUVOMCv9mb3TwYQcE7qhMovHWhLmpFhlfO4a
 -----END PGP PRIVATE KEY BLOCK-----
 """
 
-    NON_DEFAULT_KEY_ID = '6A93393F50C5E6ACD3D6FB45B936212EDB4E14C0'
+    NON_DEFAULT_KEY_ID = "6A93393F50C5E6ACD3D6FB45B936212EDB4E14C0"
 
     def setUp(self):
         super(PorcelainGpgTestCase, self).setUp()
@@ -257,10 +258,20 @@ AanKpb2pqswnk1CVhAzh+l7JhOR5RUVOMCv9mb3TwYQcE7qhMovHWhLmpFhlfO4a
         self.addCleanup(os.environ.__setitem__, "GNUPGHOME", self._old_gnupghome)
 
     def import_default_key(self):
-        subprocess.run(['gpg', '--import'], capture_output=True, input=PorcelainGpgTestCase.DEFAULT_KEY, text=True)
+        subprocess.run(
+            ["gpg", "--import"],
+            capture_output=True,
+            input=PorcelainGpgTestCase.DEFAULT_KEY,
+            text=True,
+        )
 
     def import_non_default_key(self):
-        subprocess.run(['gpg', '--import'], capture_output=True, input=PorcelainGpgTestCase.NON_DEFAULT_KEY, text=True)
+        subprocess.run(
+            ["gpg", "--import"],
+            capture_output=True,
+            input=PorcelainGpgTestCase.NON_DEFAULT_KEY,
+            text=True,
+        )
 
 
 class ArchiveTests(PorcelainTestCase):
@@ -617,7 +628,7 @@ class CloneTests(PorcelainTestCase):
         f1_1 = make_object(Blob, data=b"f1")
         trees = {1: [(b"f1", f1_1), (b"f2", f1_1)]}
         [c1] = build_commit_graph(self.repo.object_store, [[1]], trees)
-        self.repo.refs.set_symbolic_ref(b'HEAD', b'refs/heads/else')
+        self.repo.refs.set_symbolic_ref(b"HEAD", b"refs/heads/else")
         self.repo.refs[b"refs/heads/else"] = c1.id
         target_path = tempfile.mkdtemp()
         errstream = BytesIO()
@@ -631,7 +642,7 @@ class CloneTests(PorcelainTestCase):
         self.assertEqual(0, len(target_repo.open_index()))
         self.assertEqual(c1.id, target_repo.refs[b"refs/heads/else"])
         self.assertEqual(c1.id, target_repo.refs[b"HEAD"])
-        self.assertEqual({b'HEAD': b'refs/heads/else'}, target_repo.refs.get_symrefs())
+        self.assertEqual({b"HEAD": b"refs/heads/else"}, target_repo.refs.get_symrefs())
 
 
 class InitTests(TestCase):
@@ -1078,6 +1089,7 @@ class RevListTests(PorcelainTestCase):
             c3.id + b"\n" + c2.id + b"\n" + c1.id + b"\n", outstream.getvalue()
         )
 
+
 class TagCreateSignTests(PorcelainGpgTestCase):
     def test_default_key(self):
         c1, c2, c3 = build_commit_graph(
@@ -1085,7 +1097,7 @@ class TagCreateSignTests(PorcelainGpgTestCase):
         )
         self.repo.refs[b"HEAD"] = c3.id
         cfg = self.repo.get_config()
-        cfg.set(('user',), 'signingKey', PorcelainGpgTestCase.DEFAULT_KEY_ID)
+        cfg.set(("user",), "signingKey", PorcelainGpgTestCase.DEFAULT_KEY_ID)
         self.import_default_key()
 
         porcelain.tag_create(
@@ -1094,7 +1106,7 @@ class TagCreateSignTests(PorcelainGpgTestCase):
             b"foo <foo@bar.com>",
             b"bar",
             annotated=True,
-            sign=True
+            sign=True,
         )
 
         tags = self.repo.refs.as_dict(b"refs/tags")
@@ -1106,7 +1118,11 @@ class TagCreateSignTests(PorcelainGpgTestCase):
         self.assertLess(time.time() - tag.tag_time, 5)
         # GPG Signatures aren't deterministic, so we can't do a static assertion.
         # Instead we need to check the signature can be verified by git
-        subprocess.run(["git", f"--git-dir={self.repo.controldir()}", "tag", "-v", "tryme"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", f"--git-dir={self.repo.controldir()}", "tag", "-v", "tryme"],
+            check=True,
+            capture_output=True,
+        )
 
     def test_non_default_key(self):
         c1, c2, c3 = build_commit_graph(
@@ -1114,7 +1130,7 @@ class TagCreateSignTests(PorcelainGpgTestCase):
         )
         self.repo.refs[b"HEAD"] = c3.id
         cfg = self.repo.get_config()
-        cfg.set(('user',), 'signingKey', PorcelainGpgTestCase.DEFAULT_KEY_ID)
+        cfg.set(("user",), "signingKey", PorcelainGpgTestCase.DEFAULT_KEY_ID)
         self.import_non_default_key()
 
         porcelain.tag_create(
@@ -1123,7 +1139,7 @@ class TagCreateSignTests(PorcelainGpgTestCase):
             b"foo <foo@bar.com>",
             b"bar",
             annotated=True,
-            sign=PorcelainGpgTestCase.NON_DEFAULT_KEY_ID
+            sign=PorcelainGpgTestCase.NON_DEFAULT_KEY_ID,
         )
 
         tags = self.repo.refs.as_dict(b"refs/tags")
@@ -1135,7 +1151,12 @@ class TagCreateSignTests(PorcelainGpgTestCase):
         self.assertLess(time.time() - tag.tag_time, 5)
         # GPG Signatures aren't deterministic, so we can't do a static assertion.
         # Instead we need to check the signature can be verified by git
-        subprocess.run(["git", f"--git-dir={self.repo.controldir()}", "tag", "-v", "tryme"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", f"--git-dir={self.repo.controldir()}", "tag", "-v", "tryme"],
+            check=True,
+            capture_output=True,
+        )
+
 
 class TagCreateTests(PorcelainTestCase):
     def test_annotated(self):

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -22,6 +22,7 @@
 
 from io import BytesIO, StringIO
 import os
+import platform
 import re
 import shutil
 import stat
@@ -1095,7 +1096,7 @@ class RevListTests(PorcelainTestCase):
         )
 
 
-@skipIf('__pypy__' not in sys.modules or sys.platform == "win32", "gpgme not easily available or supported on Windows and PyPy")
+@skipIf(platform.python_implementation() == "PyPy" or sys.platform == "win32", "gpgme not easily available or supported on Windows and PyPy")
 class TagCreateSignTests(PorcelainGpgTestCase):
     def test_default_key(self):
         c1, c2, c3 = build_commit_graph(

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -260,7 +260,7 @@ AanKpb2pqswnk1CVhAzh+l7JhOR5RUVOMCv9mb3TwYQcE7qhMovHWhLmpFhlfO4a
     def import_default_key(self):
         subprocess.run(
             ["gpg", "--import"],
-            capture_output=True,
+            stdout=subprocess.DEVNULL,
             input=PorcelainGpgTestCase.DEFAULT_KEY,
             text=True,
         )
@@ -268,7 +268,7 @@ AanKpb2pqswnk1CVhAzh+l7JhOR5RUVOMCv9mb3TwYQcE7qhMovHWhLmpFhlfO4a
     def import_non_default_key(self):
         subprocess.run(
             ["gpg", "--import"],
-            capture_output=True,
+            stdout=subprocess.DEVNULL,
             input=PorcelainGpgTestCase.NON_DEFAULT_KEY,
             text=True,
         )
@@ -1121,7 +1121,7 @@ class TagCreateSignTests(PorcelainGpgTestCase):
         subprocess.run(
             ["git", "--git-dir={}".format(self.repo.controldir()), "tag", "-v", "tryme"],
             check=True,
-            capture_output=True,
+            stdout=subprocess.DEVNULL,
         )
 
     def test_non_default_key(self):
@@ -1154,7 +1154,7 @@ class TagCreateSignTests(PorcelainGpgTestCase):
         subprocess.run(
             ["git", "--git-dir={}".format(self.repo.controldir()), "tag", "-v", "tryme"],
             check=True,
-            capture_output=True,
+            stdout=subprocess.DEVNULL,
         )
 
 

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -1119,7 +1119,7 @@ class TagCreateSignTests(PorcelainGpgTestCase):
         # GPG Signatures aren't deterministic, so we can't do a static assertion.
         # Instead we need to check the signature can be verified by git
         subprocess.run(
-            ["git", f"--git-dir={self.repo.controldir()}", "tag", "-v", "tryme"],
+            ["git", "--git-dir={}".format(self.repo.controldir()), "tag", "-v", "tryme"],
             check=True,
             capture_output=True,
         )
@@ -1152,7 +1152,7 @@ class TagCreateSignTests(PorcelainGpgTestCase):
         # GPG Signatures aren't deterministic, so we can't do a static assertion.
         # Instead we need to check the signature can be verified by git
         subprocess.run(
-            ["git", f"--git-dir={self.repo.controldir()}", "tag", "-v", "tryme"],
+            ["git", "--git-dir={}".format(self.repo.controldir()), "tag", "-v", "tryme"],
             check=True,
             capture_output=True,
         )

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -910,7 +910,7 @@ class TagCreateTests(PorcelainTestCase):
         tag = self.repo[b"refs/tags/tryme"]
         self.assertTrue(isinstance(tag, Tag))
         self.assertEqual(b"foo <foo@bar.com>", tag.tagger)
-        self.assertEqual(b"bar", tag.message)
+        self.assertEqual(b"bar\n", tag.message)
         self.assertLess(time.time() - tag.tag_time, 5)
 
     def test_unannotated(self):

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -262,7 +262,7 @@ AanKpb2pqswnk1CVhAzh+l7JhOR5RUVOMCv9mb3TwYQcE7qhMovHWhLmpFhlfO4a
             ["gpg", "--import"],
             stdout=subprocess.DEVNULL,
             input=PorcelainGpgTestCase.DEFAULT_KEY,
-            text=True,
+            universal_newlines=True,
         )
 
     def import_non_default_key(self):
@@ -270,7 +270,7 @@ AanKpb2pqswnk1CVhAzh+l7JhOR5RUVOMCv9mb3TwYQcE7qhMovHWhLmpFhlfO4a
             ["gpg", "--import"],
             stdout=subprocess.DEVNULL,
             input=PorcelainGpgTestCase.NON_DEFAULT_KEY,
-            text=True,
+            universal_newlines=True,
         )
 
 

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -26,9 +26,11 @@ import re
 import shutil
 import stat
 import subprocess
+import sys
 import tarfile
 import tempfile
 import time
+from unittest import skipIf
 
 from dulwich import porcelain
 from dulwich.diff_tree import tree_changes
@@ -1093,6 +1095,7 @@ class RevListTests(PorcelainTestCase):
         )
 
 
+@skipIf('__pypy__' not in sys.modules or sys.platform == "win32", "gpgme not easily available or supported on Windows and PyPy")
 class TagCreateSignTests(PorcelainGpgTestCase):
     def test_default_key(self):
         c1, c2, c3 = build_commit_graph(

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -255,7 +255,10 @@ AanKpb2pqswnk1CVhAzh+l7JhOR5RUVOMCv9mb3TwYQcE7qhMovHWhLmpFhlfO4a
         self.addCleanup(shutil.rmtree, self.gpg_dir)
         self._old_gnupghome = os.environ.get("GNUPGHOME")
         os.environ["GNUPGHOME"] = self.gpg_dir
-        self.addCleanup(os.environ.__setitem__, "GNUPGHOME", self._old_gnupghome)
+        if self._old_gnupghome is None:
+            self.addCleanup(os.environ.__delitem__, "GNUPGHOME")
+        else:
+            self.addCleanup(os.environ.__setitem__, "GNUPGHOME", self._old_gnupghome)
 
     def import_default_key(self):
         subprocess.run(


### PR DESCRIPTION
This PR fixes two compatibility issues with git around signed tags, and adds support for specifying a signing Key ID to use when creating a signed tag.

The first issue is the serialisation logic for tags. When git creates a signed tag, it includes a new line at the end of the buffer being signed. If this isn't included, then git will not parse the tag signature and if it's included when serialising the tag signature itself, git will be performing signature verification on different data to what was signed, leading to signature verification failure.

The second issue this PR fixes is with the GPG signature mode used. By specifying that a detached signature is being made, Dulwich will create the same format of tag signature as git (see https://github.com/git/git/blob/84d06cdc06389ae7c462434cb7b1db0980f63860/gpg-interface.c#L453 relevant option is -b, which tells GPG to make a detached signature).

Lastly I've added support for overloading the sign parameter to porcelain.tag_create, which when passed a str containing a key id will use that key id to perform signing.

Because there aren't existing tests for tag signing, I'm not sure how to structure these, any advice would be greatly appreciated