### PR TITLE
config: check default system paths on windows

### DIFF
--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -524,6 +524,13 @@ class StackedConfig(Config):
 
         if "GIT_CONFIG_NOSYSTEM" not in os.environ:
             paths.append("/etc/gitconfig")
+            if sys.platform == "win32":
+                paths.extend(
+                    [
+                        "C:/Program Files/Git/etc/gitconfig",
+                        "C:/ProgramData/Git/config",
+                    ]
+                )
 
         backends = []
         for path in paths:

--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -535,13 +535,13 @@ def _find_git_in_win_reg():
 
 # There is no set standard for system config dirs on windows. We try the
 # following:
-#   - %ProgramData%/Git/config - (deprecated) Windows config dir per CGit docs
-#   - %ProgramFiles%/Git/etc/gitconfig - Git for Windows (msysgit) config dir
+#   - %PROGRAMDATA%/Git/config - (deprecated) Windows config dir per CGit docs
+#   - %PROGRAMFILES%/Git/etc/gitconfig - Git for Windows (msysgit) config dir
 #     Used if CGit installation (Git/bin/git.exe) is found in PATH in the
 #     system registry
 def get_win_system_paths():
-    if "ProgramData" in os.environ:
-        yield os.path.join(os.environ["ProgramData"], "Git", "config")
+    if "PROGRAMDATA" in os.environ:
+        yield os.path.join(os.environ["PROGRAMDATA"], "Git", "config")
 
     for git_dir in _find_git_in_win_path():
         yield os.path.join(git_dir, "etc", "gitconfig")

--- a/dulwich/tests/test_config.py
+++ b/dulwich/tests/test_config.py
@@ -294,7 +294,7 @@ class StackedConfigTests(TestCase):
             paths = set(get_win_system_paths())
         self.assertEqual(
             {
-                os.path.join(os.environ.get("ProgramData"), "Git", "config"),
+                os.path.join(os.environ.get("PROGRAMDATA"), "Git", "config"),
                 os.path.join(install_dir, "etc", "gitconfig"),
             },
             paths,
@@ -316,7 +316,7 @@ class StackedConfigTests(TestCase):
                 paths = set(get_win_system_paths())
         self.assertEqual(
             {
-                os.path.join(os.environ.get("ProgramData"), "Git", "config"),
+                os.path.join(os.environ.get("PROGRAMDATA"), "Git", "config"),
                 os.path.join(install_dir, "etc", "gitconfig"),
             },
             paths,


### PR DESCRIPTION
Will close #865 

from https://github.com/dulwich/dulwich/issues/865#issuecomment-828274471
> I guess checking for the system config on windows isn't exactly straightforward since it depends on where the user installed Git (it will be in `<path-to-git-installation>/etc/gitconfig`
> 
> But it reasonable for dulwich to at least check `C:\Program Files\Git\etc\gitconfig` (current default Git for Windows install location) and `C:\ProgramData\Git\config` (alternate system config location in vista+ from the [git docs](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup))
