### PR TITLE
tests: fix windows crlf CI issues

### DIFF
--- a/dulwich/tests/__init__.py
+++ b/dulwich/tests/__init__.py
@@ -43,6 +43,7 @@ class TestCase(_TestCase):
         super(TestCase, self).setUp()
         self._old_home = os.environ.get("HOME")
         os.environ["HOME"] = "/nonexistant"
+        os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
 
     def tearDown(self):
         super(TestCase, self).tearDown()

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -1820,11 +1820,6 @@ class StatusTests(PorcelainTestCase):
         with open(file_path, "wb") as f:
             f.write(b"line1\r\nline2")
 
-        if sys.platform == "win32":
-            c = self.repo.get_config()
-            c.set("core", "autocrlf", "false")
-            c.write_to_path()
-
         results = porcelain.status(self.repo)
         self.assertDictEqual({"add": [], "delete": [], "modify": []}, results.staged)
         self.assertListEqual(results.unstaged, [b"crlf"])
@@ -1861,10 +1856,6 @@ class StatusTests(PorcelainTestCase):
 
     def test_status_autocrlf_input(self):
         # Commit existing file with CRLF
-        c = self.repo.get_config()
-        c.set("core", "autocrlf", "false")
-        c.write_to_path()
-
         file_path = os.path.join(self.repo.path, "crlf-exists")
         with open(file_path, "wb") as f:
             f.write(b"line1\r\nline2")

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -1820,6 +1820,11 @@ class StatusTests(PorcelainTestCase):
         with open(file_path, "wb") as f:
             f.write(b"line1\r\nline2")
 
+        if sys.platform == "win32":
+            c = self.repo.get_config()
+            c.set("core", "autocrlf", "false")
+            c.write_to_path()
+
         results = porcelain.status(self.repo)
         self.assertDictEqual({"add": [], "delete": [], "modify": []}, results.staged)
         self.assertListEqual(results.unstaged, [b"crlf"])
@@ -1856,6 +1861,10 @@ class StatusTests(PorcelainTestCase):
 
     def test_status_autocrlf_input(self):
         # Commit existing file with CRLF
+        c = self.repo.get_config()
+        c.set("core", "autocrlf", "false")
+        c.write_to_path()
+
         file_path = os.path.join(self.repo.path, "crlf-exists")
         with open(file_path, "wb") as f:
             f.write(b"line1\r\nline2")


### PR DESCRIPTION
Fixes windows specific CI test failures that resulted from the crlf & windows system config changes

Now that dulwich reads CGit global config on windows, it now picks up `autocrlf = True` from the system wide config that was ignored before. This made some windows autocrlf test bugs show up (the tests assumed autocrlf was always disabled by default on all platforms which is no longer the case)