### PR TITLE
gha: publish: don't forget gpg

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -30,10 +30,19 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install native dependencies (Ubuntu)
+      run: sudo apt-get update && sudo apt-get install -y libgpgme-dev libgpg-error-dev
+      if: "matrix.os == 'ubuntu-latest'"
+    - name: Install native dependencies (MacOS)
+      run: brew install swig gpgme
+      if: "matrix.os == 'macos-latest'"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine fastimport
+    - name: Install gpg on supported platforms
+      run: pip install -U gpg
+      if: "matrix.os != 'windows-latest' && matrix.python-version != 'pypy3'"
     - name: Run test suite
       run: |
         python -m unittest dulwich.tests.test_suite


### PR DESCRIPTION
Latest release is missing mac and linux wheels. From https://github.com/dulwich/dulwich/runs/2651889610?check_suite_focus=true

```
======================================================================
ERROR: test_default_key (dulwich.tests.test_porcelain.TagCreateSignTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/runner/work/dulwich/dulwich/dulwich/tests/test_porcelain.py", line 1108, in test_default_key
    import gpg
ModuleNotFoundError: No module named 'gpg'

======================================================================
ERROR: test_non_default_key (dulwich.tests.test_porcelain.TagCreateSignTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/runner/work/dulwich/dulwich/dulwich/tests/test_porcelain.py", line 1167, in test_non_default_key
    sign=PorcelainGpgTestCase.NON_DEFAULT_KEY_ID,
  File "/Users/runner/work/dulwich/dulwich/dulwich/porcelain.py", line 961, in tag_create
    tag_obj.sign(sign if isinstance(sign, str) else None)
  File "/Users/runner/work/dulwich/dulwich/dulwich/objects.py", line 871, in sign
    import gpg
ModuleNotFoundError: No module named 'gpg'

======================================================================
ERROR: test_sign (dulwich.tests.compat.test_porcelain.TagCreateSignTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/runner/work/dulwich/dulwich/dulwich/tests/compat/test_porcelain.py", line 62, in test_sign
    sign=True,
  File "/Users/runner/work/dulwich/dulwich/dulwich/porcelain.py", line 961, in tag_create
    tag_obj.sign(sign if isinstance(sign, str) else None)
  File "/Users/runner/work/dulwich/dulwich/dulwich/objects.py", line 871, in sign
    import gpg
ModuleNotFoundError: No module named 'gpg'

======================================================================
ERROR: test_verify (dulwich.tests.compat.test_porcelain.TagCreateSignTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/runner/work/dulwich/dulwich/dulwich/tests/compat/test_porcelain.py", line 101, in test_verify
    tag.verify()
  File "/Users/runner/work/dulwich/dulwich/dulwich/objects.py", line 902, in verify
    import gpg
ModuleNotFoundError: No module named 'gpg'
```

Fixes https://github.com/iterative/dvc/issues/6052