### PR TITLE
config: disregard UTF-8 BOM when reading file

### DIFF
--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -395,6 +395,8 @@ class ConfigFile(ConfigDict):
         setting = None
         continuation = None
         for lineno, line in enumerate(f.readlines()):
+            if lineno == 0 and line.startswith(b'\xef\xbb\xbf'):
+                line = line[3:]
             line = line.lstrip()
             if setting is None:
                 # Parse section header ("[bla]")

--- a/dulwich/tests/test_config.py
+++ b/dulwich/tests/test_config.py
@@ -108,6 +108,11 @@ class ConfigFileTests(TestCase):
         self.assertEqual(b"bar", cf.get((b"core",), b"foo"))
         self.assertEqual(b"bar", cf.get((b"core", b"foo"), b"foo"))
 
+    def test_from_file_utf8_bom(self):
+        text = "[core]\nfoo = b\u00e4r\n".encode("utf-8-sig")
+        cf = self.from_file(text)
+        self.assertEqual(b"b\xc3\xa4r", cf.get((b"core",), b"foo"))
+
     def test_from_file_section_case_insensitive_lower(self):
         cf = self.from_file(b"[cOre]\nfOo = bar\n")
         self.assertEqual(b"bar", cf.get((b"core",), b"foo"))


### PR DESCRIPTION
Previously, reading a config file that started with an UTF-8 BOM would die with an error. This was originally reported to hg-git, where we use `Config.from_file()` for reading `.gitmodules`.

Originally reported to `hg-git` on [Heptapod](https://foss.heptapod.net/mercurial/hg-git/-/issues/354).