### PR TITLE
use list() to change fs_paths to list

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1263,7 +1263,7 @@ class Repo(BaseRepo):
         root_path_bytes = os.fsencode(self.path)
 
         if not isinstance(fs_paths, list):
-            fs_paths = [fs_paths]
+            fs_paths = list(fs_paths)
         from dulwich.index import (
             blob_from_path_and_stat,
             index_entry_from_stat,

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1262,8 +1262,10 @@ class Repo(BaseRepo):
 
         root_path_bytes = os.fsencode(self.path)
 
-        if not isinstance(fs_paths, list):
-            fs_paths = list(fs_paths)
+        if isinstance(fs_paths, str):
+            fs_paths = [fs_paths]
+        fs_paths = list(fs_paths)
+
         from dulwich.index import (
             blob_from_path_and_stat,
             index_entry_from_stat,


### PR DESCRIPTION
Using `list()` to format fs_paths will not only access type `str` but also access type `tuple` and type `set`.