### PR TITLE
Unbreak `dulwich` script

### DIFF
--- a/dulwich/__main__.py
+++ b/dulwich/__main__.py
@@ -1,0 +1,4 @@
+from . import cli
+
+if __name__ == "__main__":
+    cli._main()

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -731,7 +731,7 @@ commands = {
 
 def main(argv=None):
     if argv is None:
-        argv = sys.argv
+        argv = sys.argv[1:]
 
     if len(argv) < 1:
         print("Usage: dulwich <%s> [OPTIONS...]" % ("|".join(commands.keys())))
@@ -752,4 +752,4 @@ if __name__ == "__main__":
         signal.signal(signal.SIGQUIT, signal_quit)  # type: ignore
     signal.signal(signal.SIGINT, signal_int)
 
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main())

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -747,9 +747,13 @@ def main(argv=None):
     return cmd_kls().run(argv[1:])
 
 
-if __name__ == "__main__":
+def _main():
     if "DULWICH_PDB" in os.environ and getattr(signal, "SIGQUIT", None):
         signal.signal(signal.SIGQUIT, signal_quit)  # type: ignore
     signal.signal(signal.SIGINT, signal_int)
 
     sys.exit(main())
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
The first value in `sys.argv` is the name of the script invoked, with actual arguments following. Previously, any attempt to invoke the script would yield e.g.:

    $ dulwich
    No such subcommand: /path/to/dulwich

This was presumably never noticed due to `python -m dulwich.cli` explicitly passing in `sys.argv[1:]`.

I've also added support for invoking the package directly, using `python -m dulwich`, consistent with e.g. `pip`. `python -m dulwich.cli` still works as well.