### PR TITLE
don't create unwritable files on Windows

### DIFF
--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -70,7 +70,10 @@ from dulwich.refs import ANNOTATED_TAG_SUFFIX
 INFODIR = "info"
 PACKDIR = "pack"
 
-PACK_MODE = 0o444
+# use permissions consistent with Git; just readable by everyone
+# TODO: should packs also be non-writable on Windows? if so, that
+# would requite some rather significant adjustments to the test suite
+PACK_MODE = 0o444 if sys.platform != "win32" else 0o644
 
 
 class BaseObjectStore(object):

--- a/dulwich/tests/test_object_store.py
+++ b/dulwich/tests/test_object_store.py
@@ -27,6 +27,7 @@ from unittest import skipUnless
 import os
 import shutil
 import stat
+import sys
 import tempfile
 
 from dulwich.index import (
@@ -443,7 +444,8 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
         path = self.store._get_shafile_path(testobject.id)
         mode = os.stat(path).st_mode
 
-        self.assertEqual(oct(mode), "0o100444")
+        packmode = "0o100444" if sys.platform != "win32" else "0o100666"
+        self.assertEqual(oct(mode), packmode)
 
     def test_corrupted_object_raise_exception(self):
         """Corrupted sha1 disk file should raise specific exception"""

--- a/dulwich/tests/test_pack.py
+++ b/dulwich/tests/test_pack.py
@@ -26,6 +26,7 @@ from io import BytesIO
 from hashlib import sha1
 import os
 import shutil
+import sys
 import tempfile
 import zlib
 
@@ -83,6 +84,7 @@ pack1_sha = b"bc63ddad95e7321ee734ea11a7a62d314e0d7481"
 a_sha = b"6f670c0fb53f9463760b7295fbb814e965fb20c8"
 tree_sha = b"b2a2766a2879c209ab1176e7e778b81ae422eeaa"
 commit_sha = b"f18faa16531ac570a3fdc8c7ca16682548dafd12"
+indexmode = "0o100644" if sys.platform != "win32" else "0o100666"
 
 
 class PackTests(TestCase):
@@ -338,7 +340,7 @@ class TestPackData(PackTests):
             p.create_index_v1(filename)
             idx1 = load_pack_index(filename)
             idx2 = self.get_pack_index(pack1_sha)
-            self.assertEqual(oct(os.stat(filename).st_mode), "0o100644")
+            self.assertEqual(oct(os.stat(filename).st_mode), indexmode)
             self.assertEqual(idx1, idx2)
 
     def test_create_index_v2(self):
@@ -347,7 +349,7 @@ class TestPackData(PackTests):
             p.create_index_v2(filename)
             idx1 = load_pack_index(filename)
             idx2 = self.get_pack_index(pack1_sha)
-            self.assertEqual(oct(os.stat(filename).st_mode), "0o100644")
+            self.assertEqual(oct(os.stat(filename).st_mode), indexmode)
             self.assertEqual(idx1, idx2)
 
     def test_compute_file_sha(self):

--- a/dulwich/tests/utils.py
+++ b/dulwich/tests/utils.py
@@ -24,7 +24,6 @@
 import datetime
 import os
 import shutil
-import stat
 import tempfile
 import time
 import types
@@ -83,20 +82,11 @@ def open_repo(name, temp_dir=None):
     return Repo(temp_repo_dir)
 
 
-def safe_rmtree(path):
-    """Version of shutil.rmtree() that handles unwritable files"""
-    def really_delete(action, name, exc):
-        os.chmod(name, stat.S_IWRITE)
-        os.remove(name)
-
-    shutil.rmtree(path, onerror=really_delete)
-
-
 def tear_down_repo(repo):
     """Tear down a test repository."""
     repo.close()
     temp_dir = os.path.dirname(repo.path.rstrip(os.sep))
-    safe_rmtree(temp_dir)
+    shutil.rmtree(temp_dir)
 
 
 def make_object(cls, **attrs):


### PR DESCRIPTION
This is a follow-up to #892 which broke the test suite on Windows. I haven't what Git does with permissions on that platform, so it seems better to leave it be.