### PR TITLE
post-receive hook: error encoding fixes for Python 3.

### DIFF
--- a/dulwich/hooks.py
+++ b/dulwich/hooks.py
@@ -193,12 +193,12 @@ class PostReceiveShellHook(ShellHook):
             )
 
             # client_refs is a list of (oldsha, newsha, ref)
-            in_data = "\n".join([" ".join(ref) for ref in client_refs])
+            in_data = b"\n".join([b" ".join(ref) for ref in client_refs])
 
             out_data, err_data = p.communicate(in_data)
 
             if (p.returncode != 0) or err_data:
-                err_fmt = "post-receive exit code: %d\n" + "stdout:\n%s\nstderr:\n%s"
+                err_fmt = b"post-receive exit code: %d\n" + b"stdout:\n%s\nstderr:\n%s"
                 err_msg = err_fmt % (p.returncode, out_data, err_data)
                 raise HookError(err_msg.decode('utf-8', 'backslashreplace'))
             return out_data


### PR DESCRIPTION
Problem:
p.communicate expects bytes in and bytes out.
When out_data is not empty, the code formatting err_msg was producing an exception.

Solution:
Formatting everything as bytes literals.