### PR TITLE
Fixes `Tag.signature` field

### DIFF
--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -873,12 +873,12 @@ class Tag(ShaFile):
             if keyid is not None:
                 key = c.get_key(keyid)
                 with gpg.Context(armor=True, signers=[key]) as ctx:
-                    self.signature, unused_result = ctx.sign(
+                    self._signature, unused_result = ctx.sign(
                         self.as_raw_string(),
                         mode=gpg.constants.sig.mode.DETACH,
                     )
             else:
-                self.signature, unused_result = c.sign(
+                self._signature, unused_result = c.sign(
                     self.as_raw_string(), mode=gpg.constants.sig.mode.DETACH
                 )
 


### PR DESCRIPTION
I am opening this PR, because new version of `mypy` identified a bug in this definition.
`self.signature` is not in `__slots__`. I looked like a typo.
Unit tests in `tests/` seem to ignore this method.

Please, feel free to close if this is not a bug and there's some extra magic I've missed.
Related https://github.com/python/mypy/pull/10864