### PR TITLE
client: add support for GIT_SSH_COMMAND

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1515,7 +1515,10 @@ class SubprocessSSHVendor(SSHVendor):
                 "Setting password not supported by SubprocessSSHVendor."
             )
 
-        args = [ssh_command or "ssh", "-x"]
+        if ssh_command:
+            args = ssh_command.split() + ["-x"]
+        else:
+            args = ["ssh", "-x"]
 
         if port:
             args.extend(["-p", str(port)])
@@ -1554,7 +1557,7 @@ class PLinkSSHVendor(SSHVendor):
     ):
 
         if ssh_command:
-            args = [ssh_command, "-ssh"]
+            args = ssh_command.split() + ["-ssh"]
         elif sys.platform == "win32":
             args = ["plink.exe", "-ssh"]
         else:

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -43,6 +43,7 @@ from io import BytesIO, BufferedReader
 import logging
 import os
 import select
+import shlex
 import socket
 import subprocess
 import sys
@@ -1516,7 +1517,7 @@ class SubprocessSSHVendor(SSHVendor):
             )
 
         if ssh_command:
-            args = ssh_command.split() + ["-x"]
+            args = shlex.split(ssh_command) + ["-x"]
         else:
             args = ["ssh", "-x"]
 
@@ -1557,7 +1558,7 @@ class PLinkSSHVendor(SSHVendor):
     ):
 
         if ssh_command:
-            args = ssh_command.split() + ["-ssh"]
+            args = shlex.split(ssh_command) + ["-ssh"]
         elif sys.platform == "win32":
             args = ["plink.exe", "-ssh"]
         else:

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -1249,7 +1249,9 @@ class SubprocessSSHVendorTests(TestCase):
 
     def test_run_with_ssh_command(self):
         expected = [
-            "/path/to/ssh -o Option=Value",
+            "/path/to/ssh",
+            "-o",
+            "Option=Value",
             "-x",
             "host",
             "git-clone-url",

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -705,6 +705,7 @@ class TestSSHVendor(object):
         port=None,
         password=None,
         key_filename=None,
+        ssh_command=None,
     ):
         self.host = host
         self.command = command
@@ -712,6 +713,7 @@ class TestSSHVendor(object):
         self.port = port
         self.password = password
         self.key_filename = key_filename
+        self.ssh_command = ssh_command
 
         class Subprocess:
             pass
@@ -784,6 +786,21 @@ class SSHGitClientTests(TestCase):
 
         client._connect(b"relative-command", b"/~/path/to/repo")
         self.assertEqual("git-relative-command '~/path/to/repo'", server.command)
+
+    def test_ssh_command_precedence(self):
+        os.environ["GIT_SSH"] = "/path/to/ssh"
+        test_client = SSHGitClient("git.samba.org")
+        self.assertEqual(test_client.ssh_command, "/path/to/ssh")
+
+        os.environ["GIT_SSH_COMMAND"] = "/path/to/ssh -o Option=Value"
+        test_client = SSHGitClient("git.samba.org")
+        self.assertEqual(test_client.ssh_command, "/path/to/ssh -o Option=Value")
+
+        test_client = SSHGitClient("git.samba.org", ssh_command="ssh -o Option1=Value1")
+        self.assertEqual(test_client.ssh_command, "ssh -o Option1=Value1")
+
+        del os.environ["GIT_SSH"]
+        del os.environ["GIT_SSH_COMMAND"]
 
 
 class ReportStatusParserTests(TestCase):
@@ -1230,6 +1247,24 @@ class SubprocessSSHVendorTests(TestCase):
 
         self.assertListEqual(expected, args[0])
 
+    def test_run_with_ssh_command(self):
+        expected = [
+            "/path/to/ssh -o Option=Value",
+            "-x",
+            "host",
+            "git-clone-url",
+        ]
+
+        vendor = SubprocessSSHVendor()
+        command = vendor.run_command(
+            "host",
+            "git-clone-url",
+            ssh_command="/path/to/ssh -o Option=Value",
+        )
+
+        args = command.proc.args
+        self.assertListEqual(expected, args[0])
+
 
 class PLinkSSHVendorTests(TestCase):
     def setUp(self):
@@ -1351,6 +1386,24 @@ class PLinkSSHVendorTests(TestCase):
 
         args = command.proc.args
 
+        self.assertListEqual(expected, args[0])
+
+    def test_run_with_ssh_command(self):
+        expected = [
+            "/path/to/plink",
+            "-x",
+            "host",
+            "git-clone-url",
+        ]
+
+        vendor = SubprocessSSHVendor()
+        command = vendor.run_command(
+            "host",
+            "git-clone-url",
+            ssh_command="/path/to/plink",
+        )
+
+        args = command.proc.args
         self.assertListEqual(expected, args[0])
 
 


### PR DESCRIPTION
- Adds `ssh_command` parameter to `SSHGitClient` and `SSHVendor.run_command`
- If specified, `ssh_command` will be used instead of the default `ssh` or `plink[.exe]` executables when we run SSH via subprocess (in both `SubprocessSSHVendor` and `PLinkSSHVendor`)
    - Existing options for host/port/user/password/etc will still be appended to the command and should not be included in `ssh_command`
    - `ssh_command` is ignored for the paramiko contrib vendor
- `SSHGitClient` will use `GIT_SSH` or `GIT_SSH_COMMAND` environment variables if they are set (with precedence given to `ssh_command` > `GIT_SSH_COMMAND`, `GIT_SSH`)
    - We do not autodetect the vendor variant when `GIT_SSH` or `GIT_SSH_COMMAND` is set, currently we assume that the user has selected the appropriate dulwich SSH vendor and that it matches `GIT_SSH`/`GIT_SSH_COMMAND`

As far as I can tell this should be consistent with the cgit docs for [GIT_SSH_COMMAND](https://git-scm.com/docs/git#Documentation/git.txt-codeGITSSHcode) and [ssh.variant](https://git-scm.com/docs/git-config#Documentation/git-config.txt-sshvariant)