### PR TITLE
fix handle of gecos in case of null

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -146,7 +146,8 @@ def _get_default_identity() -> Tuple[str, str]:
         except KeyError:
             fullname = None
         else:
-            fullname = gecos.split(",")[0]
+            if not gecos:
+                fullname = gecos.split(",")[0]
     if not fullname:
         fullname = username
     email = os.environ.get("EMAIL")


### PR DESCRIPTION
e.g. termux doesn't fill the user's full name which than lead gives back null to pwd's full name request what wasn't handled by repo.py