### PR TITLE
clone: re-add progress support

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -497,7 +497,7 @@ class GitClient(object):
         raise NotImplementedError(self.send_pack)
 
     def clone(self, path, target_path, mkdir: bool = True, bare=False, origin="origin",
-              checkout=None, branch=None, depth=None):
+              checkout=None, branch=None, progress=None, depth=None):
         """Clone a repository."""
         from .refs import _set_origin_head, _set_default_branch, _set_head
         from .repo import Repo
@@ -532,7 +532,7 @@ class GitClient(object):
             target_config.write_to_path()
 
             ref_message = b"clone: from " + encoded_path
-            result = self.fetch(path, target, depth=depth)
+            result = self.fetch(path, target, progress=progress, depth=depth)
             _import_remote_refs(
                 target.refs, origin, result.refs, message=ref_message)
 

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -448,6 +448,7 @@ def clone(
         origin=origin,
         checkout=checkout,
         branch=branch,
+        progress=errstream.write,
         depth=depth,
     )
 

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1394,6 +1394,7 @@ class Repo(BaseRepo):
         origin=b"origin",
         checkout=None,
         branch=None,
+        progress=None,
         depth=None,
     ):
         """Clone this repository.
@@ -1407,6 +1408,7 @@ class Repo(BaseRepo):
             cloned from this repository
           branch: Optional branch or tag to be used as HEAD in the new repository
             instead of this repository's HEAD.
+          progress: Optional progress function
           depth: Depth at which to fetch
         Returns: Created repository as `Repo`
         """


### PR DESCRIPTION
Re-enable progress support in clone methods for reporting fetch progress

- Adds `progress=` in `Repo.clone`, `client.clone`
- Uses `progress=errstream.write` in `porcelain.clone`